### PR TITLE
Initial rook support

### DIFF
--- a/rook/README.md
+++ b/rook/README.md
@@ -1,0 +1,46 @@
+# Rook installation
+
+Also see the official documentation at <https://rook.io/docs/rook/v1.5/> and the repository at <https://github.com/rook/rook>.
+
+## Quickstart
+
+```bash
+# Make sure your KUBECONFIG and Kubernetes context are set correctly
+./deploy-rook.sh
+```
+
+## Requirements
+
+### Ceph partition or disk
+
+An empty disk or partition needs to be available.
+Ceph will create an [OSD](https://docs.ceph.com/en/latest/man/8/ceph-osd/) for each partition or disk to provide access to it.
+
+To create an empty partition `/dev/vda2` on the `/dev/vda` disk, leaving 50 GB to other partitions, use the following cloud-init config:
+
+```yaml
+#cloud-config
+bootcmd:
+- [ cloud-init-per, once, move-second-header, sgdisk, --move-second-header, /dev/vda ]
+- [ cloud-init-per, once, create-ceph-part, parted, --script, /dev/vda, 'mkpart 2 50GB -1' ]
+```
+
+### Nodes for Ceph mons
+
+The Ceph [`mon`s](https://docs.ceph.com/en/latest/man/8/ceph-mon/) should not run on the same node.
+Make sure that there are at least as many worker nodes as there are replicas of `mon`s.
+See `spec.mon.count` in [cluster.yaml](./cluster.yaml).
+
+### Monitoring with Prometheus
+
+Prometheus Operator CRDs should be installed before applying the Ceph cluster manifest if `spec.monitoring.enabled=true`.
+
+## Installation
+
+See [deploy-rook.sh](./deploy-rook.sh) for an example.
+
+## Issues
+
+If the operator seems to be unable to remove configmaps or deployments, make sure that the Kubernetes API server is able to process requests.
+For example, if cert-manager custom resources are created before cert-manager is installed, we experienced cases where the Kubernetes API server did not process requests from the Rook operator.
+This was resolved once cert-manager was installed.

--- a/rook/cluster.yaml
+++ b/rook/cluster.yaml
@@ -1,0 +1,73 @@
+# See https://rook.io/docs/rook/v1.5/ceph-cluster-crd.html and
+# https://github.com/rook/rook for examples and configuration values
+apiVersion: ceph.rook.io/v1
+kind: CephCluster
+metadata:
+  name: rook-ceph
+  namespace: rook-ceph
+spec:
+  cephVersion:
+    image: ceph/ceph:v15.2.5
+    allowUnsupported: false
+  dataDirHostPath: /var/lib/rook
+  skipUpgradeChecks: false
+  continueUpgradeAfterChecksEvenIfNotHealthy: false
+  mon:
+    count: 3
+    allowMultiplePerNode: false
+  mgr:
+    modules:
+    - name: pg_autoscaler
+      enabled: true
+  dashboard:
+    enabled: false
+  monitoring:
+    # requires Prometheus operator CRDs to be pre-installed
+    enabled: false
+  crashCollector:
+    disable: false
+  cleanupPolicy:
+    sanitizeDisks:
+      method: quick
+      dataSource: zero
+      iteration: 1
+    allowUninstallWithVolumes: false
+  resources:
+    mgr:
+      requests:
+        cpu: "100m"
+        memory: "500Mi"
+    mon:
+      requests:
+        cpu: "100m"
+        memory: "1Gi"
+    osd:
+      requests:
+        cpu: "500m"
+        memory: "1Gi"
+#    prepareosd:
+#    crashcollector:
+#    cleanup:
+  removeOSDsIfOutAndSafeToRemove: false
+  storage:
+    useAllNodes: true
+    useAllDevices: true
+
+  healthCheck:
+    daemonHealth:
+      mon:
+        disabled: false
+        interval: 45s
+      osd:
+        disabled: false
+        interval: 60s
+      status:
+        disabled: false
+        interval: 60s
+    livenessProbe:
+      mon:
+        disabled: false
+      mgr:
+        disabled: false
+      osd:
+        disabled: false

--- a/rook/deploy-rook.sh
+++ b/rook/deploy-rook.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+helm repo add rook-release https://charts.rook.io/release
+
+namespace="rook-ceph"
+release_name="rook-ceph"
+chart="rook-release/rook-ceph"
+chart_version="v1.5.3"
+
+# Install rook operator
+kubectl create namespace $namespace --dry-run -o yaml | kubectl apply -f -
+helm upgrade --install --namespace $namespace $release_name $chart \
+  --version $chart_version --values operator-values.yaml --wait
+
+# Install ceph cluster
+kubectl --namespace $namespace apply -f cluster.yaml
+
+# Create storageclass
+kubectl --namespace $namespace apply -f storageclass.yaml

--- a/rook/operator-values.yaml
+++ b/rook/operator-values.yaml
@@ -1,0 +1,2 @@
+csi:
+  enableCephfsDriver: false

--- a/rook/storageclass.yaml
+++ b/rook/storageclass.yaml
@@ -1,0 +1,33 @@
+# See https://rook.io/docs/rook/v1.5/ceph-pool-crd.html
+apiVersion: ceph.rook.io/v1
+kind: CephBlockPool
+metadata:
+  name: replicapool
+  namespace: rook-ceph
+spec:
+  failureDomain: host
+  replicated:
+    size: 2
+    requireSafeReplicaSize: true
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: rook-ceph-block
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: rook-ceph.rbd.csi.ceph.com
+parameters:
+  clusterID: rook-ceph
+  pool: replicapool
+  imageFormat: "2"
+  imageFeatures: layering
+  csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner
+  csi.storage.k8s.io/provisioner-secret-namespace: rook-ceph
+  csi.storage.k8s.io/controller-expand-secret-name: rook-csi-rbd-provisioner
+  csi.storage.k8s.io/controller-expand-secret-namespace: rook-ceph
+  csi.storage.k8s.io/node-stage-secret-name: rook-csi-rbd-node
+  csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph
+  csi.storage.k8s.io/fstype: ext4
+allowVolumeExpansion: true
+reclaimPolicy: Delete


### PR DESCRIPTION
This adds initial support for installing Rook on a fresh Kubernetes installation.

Only RBD volumes has been tested. The CephFS driver has been disabled to save resources.

So far monitoring is disabled by default, since it is not assumed that the Prometheus Operator CRDs are available.
Monitoring can be enabled at a later stage by setting `spec.monitoring.enabled=true` in `cluster.yaml` and reapplying.

The resource requests are an initial guess from running a Compliant Kubernetes service cluster with Rook, and does therefore not necessarily make sense.

For testing purposes, it could make sense to
* reduce the `mon` replica count to 1
* reduce the storageclass replication to 1
