### PR TITLE
Updated to kubespray v2.14.2

### DIFF
--- a/config/group_vars/all/all.yml
+++ b/config/group_vars/all/all.yml
@@ -1,3 +1,4 @@
+---
 ## Directory where etcd data stored
 etcd_data_dir: /var/lib/etcd
 
@@ -24,7 +25,7 @@ bin_dir: /usr/local/bin
 ## Internal loadbalancers for apiservers
 # loadbalancer_apiserver_localhost: true
 # valid options are "nginx" or "haproxy"
-# loadbalancer_apiserver_type: nginx # valid values "nginx" or "haproxy"
+# loadbalancer_apiserver_type: nginx  # valid values "nginx" or "haproxy"
 
 ## Local loadbalancer should use this port
 ## And must be set port 6443
@@ -34,11 +35,6 @@ loadbalancer_apiserver_port: 6443
 loadbalancer_apiserver_healthcheck_port: 8081
 
 ### OTHER OPTIONAL VARIABLES
-## For some things, kubelet needs to load kernel modules.  For example, dynamic kernel services are needed
-## for mounting persistent volumes into containers.  These may not be loaded by preinstall kubernetes
-## processes.  For example, ceph and rbd backed volumes.  Set to true to allow kubelet to load kernel
-## modules.
-# kubelet_load_modules: false
 
 ## Upstream dns servers
 # upstream_dns_servers:
@@ -91,3 +87,7 @@ loadbalancer_apiserver_healthcheck_port: 8081
 ## Deploy container engine
 # Set false if you want to deploy container engine manually.
 # deploy_container_engine: true
+
+## Set Pypi repo and cert accordingly
+# pyrepo_index: https://pypi.example.com/simple
+# pyrepo_cert: /etc/ssl/certs/ca-certificates.crt

--- a/config/group_vars/all/azure.yml
+++ b/config/group_vars/all/azure.yml
@@ -1,6 +1,7 @@
 ## When azure is used, you need to also set the following variables.
 ## see docs/azure.md for details on how to get these values
 
+# azure_cloud:
 # azure_tenant_id:
 # azure_subscription_id:
 # azure_aad_client_id:

--- a/config/group_vars/all/containerd.yml
+++ b/config/group_vars/all/containerd.yml
@@ -1,3 +1,4 @@
+---
 # Please see roles/container-engine/containerd/defaults/main.yml for more configuration options
 
 # containerd_config:

--- a/config/group_vars/all/docker.yml
+++ b/config/group_vars/all/docker.yml
@@ -1,3 +1,4 @@
+---
 ## Uncomment this if you want to force overlay/overlay2 as docker storage driver
 ## Please note that overlay2 is only supported on newer kernels
 # docker_storage_options: -s overlay2
@@ -8,6 +9,10 @@ docker_container_storage_setup: false
 ## It must be define a disk path for docker_container_storage_setup_devs.
 ## Otherwise docker-storage-setup will be executed incorrectly.
 # docker_container_storage_setup_devs: /dev/vdb
+
+## Uncomment this if you want to change the Docker Cgroup driver (native.cgroupdriver)
+## Valid options are systemd or cgroupfs, default is systemd
+# docker_cgroup_driver: systemd
 
 ## Uncomment this if you have more than 3 nameservers, then we'll only use the first 3.
 docker_dns_servers_strict: false

--- a/config/group_vars/all/openstack.yml
+++ b/config/group_vars/all/openstack.yml
@@ -28,6 +28,19 @@
 # external_openstack_lbaas_monitor_max_retries: "3"
 # external_openstack_lbaas_manage_security_groups: false
 # external_openstack_lbaas_internal_lb: false
+# external_openstack_network_ipv6_disabled: false
+# external_openstack_network_internal_networks:
+#   - ""
+# external_openstack_network_public_networks:
+#   - ""
+# external_openstack_metadata_search_order: "configDrive,metadataService"
+
+## Application credentials to authenticate against Keystone API
+## Those settings will take precedence over username and password that might be set your environment
+## All of them are required
+# external_openstack_application_credential_name:
+# external_openstack_application_credential_id:
+# external_openstack_application_credential_secret:
 
 ## The tag of the external OpenStack Cloud Controller image
 # external_openstack_cloud_controller_image_tag: "latest"

--- a/config/group_vars/k8s-cluster/addons.yml
+++ b/config/group_vars/k8s-cluster/addons.yml
@@ -1,3 +1,4 @@
+---
 # Kubernetes dashboard
 # RBAC required. see docs/getting-started.md for access details.
 dashboard_enabled: false
@@ -25,7 +26,7 @@ local_path_provisioner_enabled: false
 # local_path_provisioner_claim_root: /opt/local-path-provisioner/
 # local_path_provisioner_debug: false
 # local_path_provisioner_image_repo: "rancher/local-path-provisioner"
-# local_path_provisioner_image_tag: "v0.0.2"
+# local_path_provisioner_image_tag: "v0.0.14"
 # local_path_provisioner_helper_image_repo: "busybox"
 # local_path_provisioner_helper_image_tag: "latest"
 
@@ -102,6 +103,11 @@ ingress_publish_status_address: ""
 # ingress_nginx_extra_args:
 #   - --default-ssl-certificate=default/foo-tls
 
+# ambassador ingress controller deployment
+ingress_ambassador_enabled: false
+# ingress_ambassador_namespace: "ambassador"
+# ingress_ambassador_version: "*"
+
 # ALB ingress controller deployment
 ingress_alb_enabled: false
 # alb_ingress_aws_region: "us-east-1"
@@ -113,3 +119,27 @@ ingress_alb_enabled: false
 # Cert manager deployment
 cert_manager_enabled: false
 # cert_manager_namespace: "cert-manager"
+
+# MetalLB deployment
+metallb_enabled: false
+# metallb_ip_range:
+#   - "10.5.0.50-10.5.0.99"
+# metallb_version: v0.9.3
+# metallb_protocol: "layer2"
+# metallb_port: "7472"
+# metallb_limits_cpu: "100m"
+# metallb_limits_mem: "100Mi"
+# metallb_additional_address_pools:
+#   kube_service_pool:
+#     ip_range:
+#       - "10.5.1.50-10.5.1.99"
+#     protocol: "layer2"
+#     auto_assign: false
+# metallb_protocol: "bgp"
+# metallb_peers:
+#   - peer_address: 192.0.2.1
+#     peer_asn: 64512
+#     my_asn: 4200000000
+#   - peer_address: 192.0.2.2
+#     peer_asn: 64513
+#     my_asn: 4200000000

--- a/config/group_vars/k8s-cluster/k8s-cluster.yml
+++ b/config/group_vars/k8s-cluster/k8s-cluster.yml
@@ -1,3 +1,4 @@
+---
 # Kubernetes configuration dirs and system namespace.
 # Those are where all the additional config stuff goes
 # the kubernetes normally puts in /srv/kubernetes.
@@ -19,7 +20,7 @@ kube_users_dir: "{{ kube_config_dir }}/users"
 kube_api_anonymous_auth: true
 
 ## Change this to use another Kubernetes version, e.g. a current beta release
-kube_version: v1.17.12
+kube_version: v1.18.10
 
 # kubernetes image repo define
 kube_image_repo: "k8s.gcr.io"
@@ -68,6 +69,15 @@ kube_users:
 # kube_oidc_groups_claim: groups
 # kube_oidc_groups_prefix: oidc:
 
+## Variables to control webhook authn/authz
+# kube_webhook_token_auth: false
+# kube_webhook_token_auth_url: https://...
+# kube_webhook_token_auth_url_skip_tls_verify: false
+
+## For webhook authorization, authorization_modes must include Webhook
+# kube_webhook_authorization: false
+# kube_webhook_authorization_url: https://...
+# kube_webhook_authorization_url_skip_tls_verify: false
 
 # Choose network plugin (cilium, calico, contiv, weave or flannel. Use cni for generic cni plugin)
 # Can also be set to 'cloud', which lets the cloud provider setup appropriate routing
@@ -77,12 +87,12 @@ kube_network_plugin: calico
 kube_network_plugin_multus: false
 
 # Kubernetes internal network for services, unused block of space.
-kube_service_addresses: 10.96.0.0/12
+kube_service_addresses: 10.233.0.0/18
 
 # internal network. When used, it will assign IP
 # addresses from this range to individual pods.
 # This network must be unused in your network infrastructure!
-kube_pods_subnet: 192.168.0.0/16
+kube_pods_subnet: 10.233.64.0/18
 
 # internal network node size allocation (optional). This is the size allocated
 # to each node on your network.  With these defaults you should have
@@ -190,6 +200,9 @@ dns_domain: "{{ cluster_name }}"
 ## Container runtime
 ## docker for docker, crio for cri-o and containerd for containerd.
 container_manager: docker
+
+# Additional container runtimes
+kata_containers_enabled: false
 
 ## Settings for containerd runtimes (only used when container_manager is set to containerd)
 #
@@ -364,3 +377,34 @@ persistent_volumes_enabled: false
 # nvidia_driver_install_ubuntu_container: gcr.io/google-containers/ubuntu-nvidia-driver-installer@sha256:7df76a0f0a17294e86f691c81de6bbb7c04a1b4b3d4ea4e7e2cccdc42e1f6d63
 ## NVIDIA GPU device plugin image.
 # nvidia_gpu_device_plugin_container: "k8s.gcr.io/nvidia-gpu-device-plugin@sha256:0842734032018be107fa2490c98156992911e3e1f2a21e059ff0105b07dd8e9e"
+
+## Support tls min version, Possible values: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13.
+# tls_min_version: ""
+
+## Support tls cipher suites.
+# tls_cipher_suites: {}
+#   - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
+#   - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
+#   - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+#   - TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA
+#   - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+#   - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+#   - TLS_ECDHE_ECDSA_WITH_RC4_128_SHA
+#   - TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA
+#   - TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
+#   - TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+#   - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+#   - TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
+#   - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+#   - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
+#   - TLS_ECDHE_RSA_WITH_RC4_128_SHA
+#   - TLS_RSA_WITH_3DES_EDE_CBC_SHA
+#   - TLS_RSA_WITH_AES_128_CBC_SHA
+#   - TLS_RSA_WITH_AES_128_CBC_SHA256
+#   - TLS_RSA_WITH_AES_128_GCM_SHA256
+#   - TLS_RSA_WITH_AES_256_CBC_SHA
+#   - TLS_RSA_WITH_AES_256_GCM_SHA384
+#   - TLS_RSA_WITH_RC4_128_SHA
+
+## Amount of time to retain events. (default 1h0m0s)
+event_ttl_duration: "1h0m0s"

--- a/config/group_vars/k8s-cluster/k8s-net-calico.yml
+++ b/config/group_vars/k8s-cluster/k8s-net-calico.yml
@@ -25,6 +25,13 @@
 # defaults. The value should be a number, not a string.
 # calico_mtu: 1500
 
+# Configure the MTU to use for workload interfaces and tunnels.
+# - If Wireguard is enabled, set to your network MTU - 60
+# - Otherwise, if VXLAN or BPF mode is enabled, set to your network MTU - 50
+# - Otherwise, if IPIP is enabled, set to your network MTU - 20
+# - Otherwise, if not using any encapsulation, set to your network MTU.
+# calico_veth_mtu: 1440
+
 # Advertise Cluster IPs
 # calico_advertise_cluster_ips: true
 
@@ -65,3 +72,7 @@
 # calico_ip_auto_method: "interface=eth.*"
 # Choose the iptables insert mode for Calico: "Insert" or "Append".
 # calico_felix_chaininsertmode: Insert
+
+# If you want use the default route interface when you use multiple interface with dynamique route (iproute2)
+# see https://docs.projectcalico.org/reference/node/configuration : FELIX_DEVICEROUTESOURCEADDRESS
+# calico_use_default_route_src_ipaddr: false

--- a/config/group_vars/k8s-cluster/k8s-net-kube-router.yml
+++ b/config/group_vars/k8s-cluster/k8s-net-kube-router.yml
@@ -39,6 +39,9 @@
 # https://github.com/cloudnativelabs/kube-router/blob/master/docs/user-guide.md#hairpin-mode
 # kube_router_support_hairpin_mode: false
 
+# Select DNS Policy ClusterFirstWithHostNet, ClusterFirst, etc.
+# kube_router_dns_policy: ClusterFirstWithHostNet
+
 # Array of annotations for master
 # kube_router_annotations_master: []
 

--- a/config/group_vars/k8s-cluster/k8s-net-macvlan.yml
+++ b/config/group_vars/k8s-cluster/k8s-net-macvlan.yml
@@ -1,3 +1,4 @@
+---
 # private interface, on a l2-network
 macvlan_interface: "eth1"
 


### PR DESCRIPTION
To support Ubuntu 20.04 *(and just to update to the latest version as soon as possible)* we want to update kubespray to the latest version. It works with the same inventory as v2.13