### PR TITLE
bin: ansible options can be passed via wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,15 +29,16 @@ Content:
    ```
 4. Run kubespray to set up the kubernetes cluster:
    ```
-   ./bin/ck8s-kubespray apply <prefix>
+   ./bin/ck8s-kubespray apply <prefix> [<options>]
    ```
+   Any `options` added will be forwarded to ansible.
 5. Done. You should now have a working kubernetes cluster. You should also have an encrypted kubeconfig at `<CK8S_CONFIG_PATH>/.state/kube_config_<prefix>.yaml` that you can use to access the cluster.
 
 ## Running other kubespray playbooks
 
 With the following command you can run any ansible playbook available in kubespray:
 ```
-./bin/ck8s-kubespray run-playbook <prefix> <playbook>
+./bin/ck8s-kubespray run-playbook <prefix> <playbook> [<options>]
 ```
 Where `playbook` is the filename of the playbook that you want to run, e.g. `cluster.yml` if you want to create a cluster (making the command functionally the same as our `ck8s-kubespray apply` command) or `scale.yml` if you want to just add more nodes. Remember to check the kubespray documentation before running a playbook.
-This will use the inventory, group-vars, and ssh key in your config path and therefore requires that you first run the init command.
+This will use the inventory, group-vars, and ssh key in your config path and therefore requires that you first run the init command. Any `options` added will be forwarded to ansible.

--- a/bin/apply.bash
+++ b/bin/apply.bash
@@ -19,14 +19,16 @@ source venv/bin/activate
 pip install -r requirements.txt
 
 log_info "Running kubespray"
-sops_exec_file_no_fifo "${secrets[ssh_key]}" "ansible-playbook -i "${config[inventory_file]}" cluster.yml -b --private-key {}"
+sops_exec_file_no_fifo "${secrets[ssh_key]}" "ansible-playbook -i "${config[inventory_file]}" cluster.yml -b --private-key {} ${@}"
 
 popd
 
 log_info "Kubespray done"
 
-mv "${config_path}/artifacts/admin.conf" "${secrets[kube_config]}"
-sops_encrypt "${secrets[kube_config]}"
+if [ -f "${config_path}/artifacts/admin.conf" ]; then
+    mv "${config_path}/artifacts/admin.conf" "${secrets[kube_config]}"
+    sops_encrypt "${secrets[kube_config]}"
+fi
 
 log_info "Cluster created sucessfully!"
 log_info "Kubeconfig located at ${secrets[kube_config]}"

--- a/bin/ck8s-kubespray
+++ b/bin/ck8s-kubespray
@@ -12,9 +12,9 @@ usage() {
     echo "  init                                        initialize the config path" 1>&2
     echo "      args: <prefix> <flavor> <path to ssh key> [<SOPS fingerprint>]" 1>&2
     echo "  apply                                       runs kubespray to create the cluster" 1>&2
-    echo "      args: <prefix>" 1>&2
+    echo "      args: <prefix> [<options>]" 1>&2
     echo "  run-playbook                                runs any ansible playbook in kubespray" 1>&2
-    echo "      args: <prefix> <playbook>" 1>&2
+    echo "      args: <prefix> <playbook> [<options>]" 1>&2
     exit 1
 }
 
@@ -35,13 +35,14 @@ case "${1}" in
         "${here}/init.bash" "${@}"
         ;;
     apply)
-        if [ $# -ne 2 ]; then
+        if [ $# -lt 2 ]; then
             usage
         fi
-        "${here}/apply.bash"
+        shift 2
+        "${here}/apply.bash" "${@}"
         ;;
     run-playbook)
-        if [ $# -ne 3 ]; then
+        if [ $# -lt 3 ]; then
             usage
         fi
         shift 2

--- a/bin/run-playbook.bash
+++ b/bin/run-playbook.bash
@@ -7,12 +7,13 @@
 set -eu -o pipefail
 shopt -s globstar nullglob dotglob
 
-if [ $# -ne 1 ]; then
+if [ $# -lt 1 ]; then
     echo "error when running $0: argument mismatch" 1>&2
     exit 1
 fi
 
 playbook=$1
+shift 1
 
 here="$(dirname "$(readlink -f "$0")")"
 source "${here}/common.bash"
@@ -26,7 +27,7 @@ source venv/bin/activate
 pip install -r requirements.txt
 
 log_info "Running kubespray"
-sops_exec_file_no_fifo "${secrets[ssh_key]}" "ansible-playbook -i ${config[inventory_file]} ${playbook} -b --private-key {}"
+sops_exec_file_no_fifo "${secrets[ssh_key]}" "ansible-playbook -i ${config[inventory_file]} ${playbook} -b --private-key {} ${@}"
 
 popd
 


### PR DESCRIPTION
This PR adds the option to pass arguments to ansible through the wrapper.

fixes #6 

Examples: 
```
./bin/ck8s-kubespray apply wc --version
...
[ck8s] Running kubespray
ansible-playbook 2.9.6
...
```

```
./bin/ck8s-kubespray run-playbook wc facts.yml --help
...
[ck8s] Running kubespray
usage: ansible-playbook [-h] [--version] [-v] [-k]
                        [--private-key PRIVATE_KEY_FILE] [-u REMOTE_USER]
                        [-c CONNECTION] [-T TIMEOUT]
                        [--ssh-common-args SSH_COMMON_ARGS]
                        [--sftp-extra-args SFTP_EXTRA_ARGS]
                        [--scp-extra-args SCP_EXTRA_ARGS]
...
```
