### PR TITLE
gcp: add a few necessary variables

### DIFF
--- a/config/gcp/group_vars/all/ck8s-gcp.yaml
+++ b/config/gcp/group_vars/all/ck8s-gcp.yaml
@@ -1,2 +1,5 @@
 cloud_provider: gcp
 gcp_pd_csi_enabled: true
+gcp_pd_csi_sa_cred_file: "set-me"
+gcp_pd_csi_controller_replicas: 1
+gcp_pd_csi_driver_image_tag: "v0.7.0-gke.0"

--- a/config/gcp/group_vars/k8s-cluster/ck8s-k8s-cluster-gcp.yaml
+++ b/config/gcp/group_vars/k8s-cluster/ck8s-k8s-cluster-gcp.yaml
@@ -1,1 +1,2 @@
 etcd_kubeadm_enabled: true
+persistent_volumes_enabled: true


### PR DESCRIPTION
Added a few more variables to group vars, which are necessary to get the GCP persistent disk driver to work (see [this document](https://github.com/kubernetes-sigs/kubespray/blob/master/docs/gcp-pd-csi.md) and [this file](https://github.com/kubernetes-sigs/kubespray/blob/release-2.14/inventory/sample/group_vars/all/gcp.yml)).

fixes #45 