### PR TITLE
bug: kubeconfig now copied to .state dir after install

### DIFF
--- a/bin/apply.bash
+++ b/bin/apply.bash
@@ -29,6 +29,7 @@ popd
 log_info "Kubespray done"
 
 if [ -f "${config_path}/artifacts/admin.conf" ]; then
+    mkdir -p "${state_path}"
     mv "${config_path}/artifacts/admin.conf" "${secrets[kube_config]}"
     sops_encrypt "${secrets[kube_config]}"
 fi


### PR DESCRIPTION
Fixes #37

After kubespray has completed creating a cluster, admin.conf should be copied to .state/kube_config_[cluster].yaml However, currently this gives an error due to the .state directory not existing.

This PR creates that dir if it doesnt exist.