### PR TITLE
bin: add apply-ssh command to change SSH keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Content:
 
     ```bash
     export CK8S_CONFIG_PATH=~/.ck8s/my-environment
-    ./bin/ck8s-kubespray init <prefix> <flavor> <path to ssh key> [<SOPS fingerprint>]
+    ./bin/ck8s-kubespray init <prefix> <flavor> [<SOPS fingerprint>]
     ```
 
     Arguments:
@@ -47,6 +47,21 @@ Content:
 1. Done.
    You should now have a working kubernetes cluster.
    You should also have an encrypted kubeconfig at `<CK8S_CONFIG_PATH>/.state/kube_config_<prefix>.yaml` that you can use to access the cluster.
+
+## Changing authorized SSH keys for a cluster
+
+Authorized SSH keys can be changed for a cluster using:
+
+```bash
+./bin/ck8s-kubespray apply-ssh <prefix> [<options>]
+```
+
+It will set the public SSH key(s) found in`<CK8S_CONFIG_PATH>/<prefix>-config/group_vars/all/ck8s-ssh-keys.yaml` as authorized keys in your cluster (just add the keys you want to be authorized as elements in `ck8s_ssh_pub_keys_list`).
+Note that the authorized SSH keys for the cluster will be set to these keys _exclusively_, removing any keys that may already be authorized, so make sure the list includes **every SSH key** that should be authorized.
+
+When running this command, the SSH keys are applied to each node in the cluster sequentially, in reverse inventory order (first the workers and then the masters).
+A connection test is performed after each node which has to succeed in order for the playbook to continue.
+If the connection test fails, you may have lost your SSH access to the node; to recover from this, you can set up an SSH connection before running the command and keep it active so that you can change the authorized keys manually.
 
 ## Running other kubespray playbooks
 

--- a/bin/apply-ssh.bash
+++ b/bin/apply-ssh.bash
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# This script will run an ansible playbook.
+# It's not to be executed on its own but rather via `ck8s-kubespray apply-ssh <prefix>`.
+
+set -eu -o pipefail
+
+here="$(dirname "$(readlink -f "$0")")"
+# shellcheck source=common.bash
+source "${here}/common.bash"
+
+log_info "Running playbook authorized_key"
+pushd "${here}/../playbooks"
+
+ansible-playbook -i "${config[inventory_file]}" authorized_key.yml "$@"
+
+popd
+
+log_info "Playbook ran successfully!"

--- a/bin/ck8s-kubespray
+++ b/bin/ck8s-kubespray
@@ -15,6 +15,8 @@ usage() {
     echo "      args: <prefix> [<options>]" 1>&2
     echo "  run-playbook                                runs any ansible playbook in kubespray" 1>&2
     echo "      args: <prefix> <playbook> [<options>]" 1>&2
+    echo "  apply-ssh                                   applies SSH keys from a file to a cluster" 1>&2
+    echo "      args: <prefix> [<options>]" 1>&2
     exit 1
 }
 
@@ -48,6 +50,13 @@ case "${1}" in
         fi
         shift 2
         "${here}/run-playbook.bash" "${@}"
+        ;;
+    apply-ssh)
+        if [ $# -lt 2 ]; then
+            usage
+        fi
+        shift 2
+        "${here}/apply-ssh.bash" "${@}"
         ;;
     *) usage ;;
 esac

--- a/config/common/group_vars/all/ck8s-ssh-keys.yaml
+++ b/config/common/group_vars/all/ck8s-ssh-keys.yaml
@@ -1,0 +1,2 @@
+ck8s_ssh_pub_keys_list:
+  -

--- a/playbooks/authorized_key.yml
+++ b/playbooks/authorized_key.yml
@@ -1,0 +1,22 @@
+- hosts: all
+  serial: 1
+  order: reverse_inventory
+  tasks:
+    - name: Check that the SSH key list file exists
+      assert:
+        that: ck8s_ssh_pub_keys_list is defined
+        fail_msg: "ck8s_ssh_pub_keys_list is undefined (the group_vars file is likely missing). Did you run ck8s-kubespray init?"
+    - name: Check that SSH key list is valid
+      assert:
+        that: ck8s_ssh_pub_keys_list and None not in ck8s_ssh_pub_keys_list
+        fail_msg: "Public SSH key list invalid - add SSH keys to ck8s_ssh_pub_keys_list"
+    - name: Add authorized keys from config folder
+      ansible.posix.authorized_key:
+        user: "{{ ansible_user }}"
+        state: present
+        exclusive: true
+        key: "{{ ck8s_ssh_pub_keys_list | join('\n') }}"
+    - name: Test connection
+      wait_for_connection:
+        delay: 1
+        timeout: 30


### PR DESCRIPTION
**What this PR does / why we need it**: Adds a command to the `ck8s-kubespray` wrapper that enables changing authorized SSH keys for a cluster.

**Which issue this PR fixes**: fixes an issue in an internal repository

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [X] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [X] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
