### PR TITLE
Added kubeadm etcd for openstack

### DIFF
--- a/config/openstack/group_vars/k8s-cluster/ck8s-k8s-cluster-openstack.yaml
+++ b/config/openstack/group_vars/k8s-cluster/ck8s-k8s-cluster-openstack.yaml
@@ -1,2 +1,4 @@
+etcd_kubeadm_enabled: true
+
 cloud_provider: openstack
 calico_mtu: 1480


### PR DESCRIPTION
**What this PR does / why we need it**:

To get citycloud work with the dynamic inventory

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [x] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
