### PR TITLE
Replace ~ with $HOME so absolute path expansion works

### DIFF
--- a/bin/common.bash
+++ b/bin/common.bash
@@ -7,9 +7,17 @@
 : "${CK8S_CONFIG_PATH:?Missing CK8S_CONFIG_PATH}"
 : "${prefix:?Missing prefix}"
 
+# Check for this mistake https://github.com/koalaman/shellcheck/wiki/SC2088
+# shellcheck disable=SC2088
+if [[ "${CK8S_CONFIG_PATH:0:2}" == "~/" ]]; then
+    echo "Warning: CK8S_CONFIG_PATH starts with unexpanded ~/" 1>&2
+    echo "This will create a new folder in cwd called ~ instead of referencing ${HOME}" 1>&2
+    echo "please use \${HOME} instead if that's what you want" 1>&2
+fi
+
 # Create CK8S_CONFIG_PATH if it does not exist and make it absolute
-mkdir -p "${CK8S_CONFIG_PATH}"
 CK8S_CONFIG_PATH=$(readlink -f "${CK8S_CONFIG_PATH}")
+mkdir -p "${CK8S_CONFIG_PATH}"
 export CK8S_CONFIG_PATH
 
 here="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"


### PR DESCRIPTION
**What this PR does / why we need it**:
Since `~` isn't expanded by `readlink` when it's in a variable I would suggest this small fix to make us able to use `~` to reference `${HOME}`

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: 
N/A

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [x] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
