### PR TITLE
add more openstack variables

### DIFF
--- a/config/openstack/group_vars/k8s-cluster/ck8s-k8s-cluster-openstack.yaml
+++ b/config/openstack/group_vars/k8s-cluster/ck8s-k8s-cluster-openstack.yaml
@@ -2,3 +2,26 @@ etcd_kubeadm_enabled: true
 
 cloud_provider: openstack
 calico_mtu: 1480
+
+## The following variables are used to enable loadbalancer services in kubernetes.
+## All of them might not be needed in your case.
+# openstack_lbaas_enabled: true
+# ## Subnet of the kubernetes nodes
+# openstack_lbaas_subnet_id: <subnet-id>
+# ## To enable automatic floating ip provisioning, specify a subnet. Often the external network.
+# openstack_lbaas_floating_network_id: <network-id>
+# ## Set use_octavia to true for citycloud
+# openstack_lbaas_use_octavia: false
+# openstack_lbaas_method: "ROUND_ROBIN"
+# openstack_lbaas_provider: "haproxy"
+# ## The following are default values in kubespray
+# openstack_lbaas_create_monitor: "yes"
+# openstack_lbaas_monitor_delay: "1m"
+# openstack_lbaas_monitor_timeout: "30s"
+# openstack_lbaas_monitor_max_retries: "3"
+# openstack_cacert: "{{ lookup('env','OS_CACERT') }}"
+
+## Here you can add additional IP addresses that will be added to the kubernetes certs.
+## They can then be used in kubeconfigs.
+## Use this to add public IPs of control-plane nodes or control-plane loadbalancers.
+# supplementary_addresses_in_ssl_keys: [<master-1-public-ip>, <master-2-public-ip>, ...]


### PR DESCRIPTION
**What this PR does / why we need it**:Added some more variables for openstack, primarily related to enabling kubernetes loadbalancer services.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [ ] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
