### PR TITLE
Small fixes: dynamic inventory path; don't force become

### DIFF
--- a/bin/apply.bash
+++ b/bin/apply.bash
@@ -22,7 +22,7 @@ source venv/bin/activate
 pip install -r requirements.txt
 
 log_info "Running kubespray"
-ansible-playbook -i "${config[inventory_file]}" cluster.yml -b ${*}
+ansible-playbook -i "${config[inventory_file]}" cluster.yml -b "${@}"
 
 popd
 

--- a/bin/common.bash
+++ b/bin/common.bash
@@ -31,6 +31,9 @@ config_path="${CK8S_CONFIG_PATH}/${prefix}-config"
 sops_config="${CK8S_CONFIG_PATH}/.sops.yaml"
 state_path="${CK8S_CONFIG_PATH}/.state"
 
+# Set the path to search for dynamic inventories
+export TERRAFORM_STATE_ROOT="${config_path}"
+
 declare -A config
 # shellcheck disable=SC2034
 config["inventory_file"]="${config_path}/inventory.ini"

--- a/bin/run-playbook.bash
+++ b/bin/run-playbook.bash
@@ -29,7 +29,7 @@ source venv/bin/activate
 pip install -r requirements.txt
 
 log_info "Running kubespray"
-ansible-playbook -i ${config[inventory_file]} ${playbook} -b ${*}
+ansible-playbook -i "${config[inventory_file]}" "${playbook}" "${@}"
 
 popd
 

--- a/docs/citycloud-snippets.md
+++ b/docs/citycloud-snippets.md
@@ -108,7 +108,7 @@ Apply the configuration and set up kubernetes.
 
 ```bash
 for CLUSTER in "${SERVICE_CLUSTER}" "${WORKLOAD_CLUSTERS[@]}"; do
-  TERRAFORM_STATE_ROOT=${CK8S_CONFIG_PATH}/${CLUSTER}-config/ bin/ck8s-kubespray apply "${CLUSTER}"
+  bin/ck8s-kubespray apply "${CLUSTER}"
 done
 ```
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixes a couple of small issues.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #31, fixes #61

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:
I'm not sure if it is a good idea to set `TERRAFORM_STATE_ROOT` in `common.bash` or if it would be better to set it in the `run-playbook.bash` and `apply.bash` scripts instead. What do you think?

**Checklist:**

- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [x] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
