### PR TITLE
config: Update kubernetes to include security patch

### DIFF
--- a/config/common/group_vars/k8s-cluster/ck8s-k8s-cluster.yaml
+++ b/config/common/group_vars/k8s-cluster/ck8s-k8s-cluster.yaml
@@ -3,6 +3,8 @@ kube_oidc_url: "https://dex.BASE-DOMAIN"
 kube_oidc_client_id: "kubelogin"
 kube_oidc_username_claim: "email"
 
+kube_version: v1.19.10
+
 kube_apiserver_enable_admission_plugins:
   - "PodSecurityPolicy"
   - "NamespaceLifecycle"


### PR DESCRIPTION
**What this PR does / why we need it**:

Update kubernetes version to include security patch.
Will require update on already running clusters.

It might be an idea to do a release of this repo before this PR is merged



**Checklist:**

- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [ ] is completely transparent, will not impact the workload in any way.
  - [x] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
