### PR TITLE
bin: Fix CK8S_CONFIG_PATH creation

### DIFF
--- a/bin/common.bash
+++ b/bin/common.bash
@@ -16,7 +16,7 @@ if [[ "${CK8S_CONFIG_PATH:0:2}" == "~/" ]]; then
 fi
 
 # Create CK8S_CONFIG_PATH if it does not exist and make it absolute
-CK8S_CONFIG_PATH=$(readlink -f "${CK8S_CONFIG_PATH}")
+CK8S_CONFIG_PATH=$(readlink -m "${CK8S_CONFIG_PATH}")
 mkdir -p "${CK8S_CONFIG_PATH}"
 export CK8S_CONFIG_PATH
 


### PR DESCRIPTION
**What this PR does / why we need it**:
readlink -f does not work for all paths that do not exists.

This changes it to use -m instead.
```
  -m, --canonicalize-missing    canonicalize by following every symlink in
                                every component of the given name recursively,
                                without requirements on components existence
```


**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [ ] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
