### PR TITLE
Allow skipping venv and requirements installation 

### DIFF
--- a/bin/apply.bash
+++ b/bin/apply.bash
@@ -15,11 +15,13 @@ log_info "Creating kubernetes cluster using kubespray"
 # shellcheck disable=SC2154
 pushd "${kubespray_path}"
 
-log_info "Installing requirements for kubespray"
-python3 -m venv venv
-# shellcheck source=../kubespray/venv/bin/activate
-source venv/bin/activate
-pip install -r requirements.txt
+if [ -z "${CK8S_KUBESPRAY_NO_VENV+x}" ]; then
+    log_info "Installing requirements for kubespray"
+    python3 -m venv venv
+    # shellcheck source=../kubespray/venv/bin/activate
+    source venv/bin/activate
+    pip install -r requirements.txt
+fi
 
 log_info "Running kubespray"
 ansible-playbook -i "${config[inventory_file]}" cluster.yml -b "${@}"

--- a/bin/run-playbook.bash
+++ b/bin/run-playbook.bash
@@ -22,11 +22,13 @@ source "${here}/common.bash"
 log_info "Running kubespray playbook ${playbook}"
 pushd "${kubespray_path}"
 
-log_info "Installing requirements for kubespray"
-python3 -m venv venv
-# shellcheck source=../kubespray/venv/bin/activate
-source venv/bin/activate
-pip install -r requirements.txt
+if [ -z "${CK8S_KUBESPRAY_NO_VENV+x}" ]; then
+    log_info "Installing requirements for kubespray"
+    python3 -m venv venv
+    # shellcheck source=../kubespray/venv/bin/activate
+    source venv/bin/activate
+    pip install -r requirements.txt
+fi
 
 log_info "Running kubespray"
 ansible-playbook -i "${config[inventory_file]}" "${playbook}" "${@}"


### PR DESCRIPTION
**What this PR does / why we need it**:

Installing the Kubespray requirements in a virtual environment is great but in certain circumstances you might want to rely on everything being installed in your current environment / system. A good example would be a pre-built Docker image where the current Kubespray version we target is already installed.

**Special notes for reviewer**:

I'm not set on the `CK8S_KUBESPRAY_NO_VENV` env name. Feel free to suggest a different, more fitting one.

**Checklist:**

- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [x] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
