### PR TITLE
Added a new entry to rook troubleshooting

### DIFF
--- a/rook/README.md
+++ b/rook/README.md
@@ -76,3 +76,41 @@ $ kubectl -n rook-ceph exec -it deploy/rook-ceph-tools -- bash
   io:
     client:   23 KiB/s rd, 6.5 MiB/s wr, 3 op/s rd, 111 op/s wr
 ```
+
+### Clock skew
+
+If rook has `HEALTH_WARN` because it has detected clock skew.
+This can be caused by system clock synchronization not being enabled.
+
+To check this run on the worker nodes:
+
+```console
+$ timedatectl status
+               Local time: tis 2021-05-18 14:04:05 CEST
+           Universal time: tis 2021-05-18 12:04:05 UTC
+                 RTC time: tis 2021-05-18 12:04:05
+                Time zone: Europe/Stockholm (CEST, +0200)
+System clock synchronized: no
+              NTP service: inactive
+          RTC in local TZ: no
+```
+
+Simply install ntp on the worker nodes and reboot:
+
+```bash
+sudo apt install ntp
+sudo reboot
+```
+
+System clock synchronization should now be enabled
+
+```console
+$ timedatectl status
+               Local time: tis 2021-05-18 14:04:05 CEST
+           Universal time: tis 2021-05-18 12:04:05 UTC
+                 RTC time: tis 2021-05-18 12:04:05
+                Time zone: Europe/Stockholm (CEST, +0200)
+System clock synchronized: yes
+              NTP service: active
+          RTC in local TZ: no
+```


### PR DESCRIPTION
**What this PR does / why we need it**:

Added some rook issues and mitigation I encountered

**Checklist:**

- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [x] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
