### PR TITLE
Added config for vSphere

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Content:
     * `prefix` will be used to differentiate this cluster from others in the same CK8S_CONFIG_PATH.
       For now you need to set this to `wc` or `sc` if you want to install compliantkubernetes apps on top afterwards, this restriction will be removed later.
     * `flavor` will determine some default values for a variety of config options.
-      Supported options are `default`, `gcp`, `aws`, and `openstack`.
+      Supported options are `default`, `gcp`, `aws`, `vsphere`, and `openstack`.
     * `SOPS fingerprint` is the gpg fingerprint that will be used for SOPS encryption.
       You need to set this or the environment variable `CK8S_PGP_FP` the first time SOPS is used in your specified config path.
 

--- a/bin/init.bash
+++ b/bin/init.bash
@@ -32,6 +32,7 @@ fi
 if [ "${flavor}" != "default" ] && \
    [ "${flavor}" != "gcp" ] && \
    [ "${flavor}" != "openstack" ] && \
+   [ "${flavor}" != "vsphere" ] && \
    [ "${flavor}" != "aws" ]; then
     log_error "ERROR: Unsupported flavor: ${flavor}"
     exit 1
@@ -71,6 +72,8 @@ elif [[ "${flavor}" == "aws" ]]; then
   cp -r "${config_defaults_path}/aws/group_vars" "${config_path}/"
 elif [[ "${flavor}" == "openstack" ]]; then
   cp -r "${config_defaults_path}/openstack/group_vars" "${config_path}/"
+elif [[ "${flavor}" == "vsphere" ]]; then
+  cp -r "${config_defaults_path}/vsphere/group_vars" "${config_path}/"
 fi
 
 # Copy inventory.ini

--- a/config/vsphere/group_vars/k8s-cluster/ck8s-k8s-cluster-vsphere.yaml
+++ b/config/vsphere/group_vars/k8s-cluster/ck8s-k8s-cluster-vsphere.yaml
@@ -14,4 +14,3 @@ external_vsphere_user: ""
 external_vsphere_datacenter: ""
 external_vsphere_kubernetes_cluster_id: ""
 vsphere_csi_enabled: true
-vsphere_csi_controller_replicas: 3

--- a/config/vsphere/group_vars/k8s-cluster/ck8s-k8s-cluster-vsphere.yaml
+++ b/config/vsphere/group_vars/k8s-cluster/ck8s-k8s-cluster-vsphere.yaml
@@ -6,8 +6,11 @@ external_cloud_provider: "vsphere"
 # For details, see https://github.com/kubernetes-sigs/kubespray/blob/master/docs/vsphere.md#out-of-tree-vsphere-cloud-provider
 external_vsphere_vcenter_ip: ""
 external_vsphere_insecure: "false"
+
+# TODO change to using environment variables when https://github.com/kubernetes-sigs/kubespray/pull/7646 is merged and in a release
 external_vsphere_user: ""
 # external_vsphere_password: "" # Set via `ansible-playbook ... --extra-vars "external_vsphere_password=${VSPHERE_PASSWORD}"`
+
 external_vsphere_datacenter: ""
 external_vsphere_kubernetes_cluster_id: ""
 vsphere_csi_enabled: true

--- a/config/vsphere/group_vars/k8s-cluster/ck8s-k8s-cluster-vsphere.yaml
+++ b/config/vsphere/group_vars/k8s-cluster/ck8s-k8s-cluster-vsphere.yaml
@@ -1,0 +1,14 @@
+etcd_kubeadm_enabled: true
+
+cloud_provider: "external"
+external_cloud_provider: "vsphere"
+
+# For details, see https://github.com/kubernetes-sigs/kubespray/blob/master/docs/vsphere.md#out-of-tree-vsphere-cloud-provider
+external_vsphere_vcenter_ip: ""
+external_vsphere_insecure: "false"
+external_vsphere_user: ""
+# external_vsphere_password: "" # Set via `ansible-playbook ... --extra-vars "external_vsphere_password=${VSPHERE_PASSWORD}"`
+external_vsphere_datacenter: ""
+external_vsphere_kubernetes_cluster_id: ""
+vsphere_csi_enabled: true
+vsphere_csi_controller_replicas: 3


### PR DESCRIPTION
**What this PR does / why we need it**:

To support vSphere setups, this makes your life it easier.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [x] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
