### PR TITLE
Added oidc groups claim in the common config

### DIFF
--- a/config/common/group_vars/k8s-cluster/ck8s-k8s-cluster.yaml
+++ b/config/common/group_vars/k8s-cluster/ck8s-k8s-cluster.yaml
@@ -2,6 +2,7 @@ kube_oidc_auth: true
 kube_oidc_url: "https://dex.BASE-DOMAIN"
 kube_oidc_client_id: "kubelogin"
 kube_oidc_username_claim: "email"
+kube_oidc_groups_claim: "groups"
 
 kube_apiserver_enable_admission_plugins:
   - "PodSecurityPolicy"


### PR DESCRIPTION
**What this PR does / why we need it**:

To be able to use groups for the kube-apiserver we need to set  this variable. Might as well have it as default.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [x] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
