### PR TITLE
bin/init: Use cloud provider instead of flavor

### DIFF
--- a/.mdl_style.rb
+++ b/.mdl_style.rb
@@ -14,6 +14,9 @@ all
 #===============================================================================
 # Exclude the rules
 
+# Allow first header to be a non-top level header.
+exclude_rule 'MD002'
+
 # We strive to not restrict line lengths
 # https://github.com/elastisys/ck8s-apps/blob/master/DEVELOPMENT.md#markdown
 exclude_rule 'MD013'

--- a/README.md
+++ b/README.md
@@ -15,16 +15,18 @@ Content:
 
     ```bash
     export CK8S_CONFIG_PATH=~/.ck8s/my-environment
-    ./bin/ck8s-kubespray init <prefix> <cloud_provider> [<SOPS fingerprint>]
+    ./bin/ck8s-kubespray init <prefix> [--cloud-provider cloud_provider] [--sops-fingerprint fingerprint]
     ```
 
     Arguments:
     * `prefix` will be used to differentiate this cluster from others in the same CK8S_CONFIG_PATH.
       For now you need to set this to `wc` or `sc` if you want to install compliantkubernetes apps on top afterwards, this restriction will be removed later.
-    * `cloud_provider` will determine some default values for a variety of config options.
+
+    Flags:
+    * `--cloud_provider` will determine some default values for a variety of config options, the environment variable `CK8S_CLOUD_PROVIDER` is used if unset.
       Supported options are `default`, `gcp`, `aws`, `vsphere`, and `openstack`.
-    * `SOPS fingerprint` is the gpg fingerprint that will be used for SOPS encryption.
-      You need to set this or the environment variable `CK8S_PGP_FP` the first time SOPS is used in your specified config path.
+    * `--sops-fingerprint` is the PGP fingerprint that will be used for SOPS encryption, the environment variable `CK8S_PGP_FP` is used if unset.
+      This flag is only required first time you configure SOPS in your specified config path.
 
 1. Edit the `inventory.ini` (found in your config path) to match the VMs (IP addresses and other settings that might be needed for your setup) that should be part of the cluster.
    Or if you have one created by a terraform script in `kubespray/contrib/terraform` you should use that one.

--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ Content:
 
     ```bash
     export CK8S_CONFIG_PATH=~/.ck8s/my-environment
-    ./bin/ck8s-kubespray init <prefix> <flavor> [<SOPS fingerprint>]
+    ./bin/ck8s-kubespray init <prefix> <cloud_provider> [<SOPS fingerprint>]
     ```
 
     Arguments:
     * `prefix` will be used to differentiate this cluster from others in the same CK8S_CONFIG_PATH.
       For now you need to set this to `wc` or `sc` if you want to install compliantkubernetes apps on top afterwards, this restriction will be removed later.
-    * `flavor` will determine some default values for a variety of config options.
+    * `cloud_provider` will determine some default values for a variety of config options.
       Supported options are `default`, `gcp`, `aws`, `vsphere`, and `openstack`.
     * `SOPS fingerprint` is the gpg fingerprint that will be used for SOPS encryption.
       You need to set this or the environment variable `CK8S_PGP_FP` the first time SOPS is used in your specified config path.

--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,8 +1,9 @@
 ### Changed
 
+- Renamed init argument flavor to cloud_provider.
+
 ### Fixed
 
 ### Added
 
 ### Removed
-

--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,6 +1,8 @@
 ### Changed
 
-- Renamed init argument flavor to cloud_provider.
+- Changed init arguments into flags:
+  - flavor -> --cloud-provider
+  - sops_fingerprint -> --sops-fingerprint
 
 ### Fixed
 

--- a/bin/ck8s-kubespray
+++ b/bin/ck8s-kubespray
@@ -10,7 +10,7 @@ here="$(dirname "$(readlink -f "$0")")"
 usage() {
     echo "COMMANDS:" 1>&2
     echo "  init                                        initialize the config path" 1>&2
-    echo "      args: <prefix> <cloud_provider> [<SOPS fingerprint>]" 1>&2
+    echo "      args: <prefix> [--cloud-provider cloud_provider] [--sops-fingerprint fingerprint]" 1>&2
     echo "  apply                                       runs kubespray to create the cluster" 1>&2
     echo "      args: <prefix> [<options>]" 1>&2
     echo "  run-playbook                                runs any ansible playbook in kubespray" 1>&2
@@ -31,7 +31,7 @@ source "${here}/common.bash"
 
 case "${1}" in
     init)
-        if [ $# -lt 3 ] || [ $# -gt 4 ]; then
+        if [ $# -lt 2 ]; then
             usage
         fi
         shift 2

--- a/bin/ck8s-kubespray
+++ b/bin/ck8s-kubespray
@@ -10,7 +10,7 @@ here="$(dirname "$(readlink -f "$0")")"
 usage() {
     echo "COMMANDS:" 1>&2
     echo "  init                                        initialize the config path" 1>&2
-    echo "      args: <prefix> <flavor> [<SOPS fingerprint>]" 1>&2
+    echo "      args: <prefix> <cloud_provider> [<SOPS fingerprint>]" 1>&2
     echo "  apply                                       runs kubespray to create the cluster" 1>&2
     echo "      args: <prefix> [<options>]" 1>&2
     echo "  run-playbook                                runs any ansible playbook in kubespray" 1>&2

--- a/bin/init.bash
+++ b/bin/init.bash
@@ -8,19 +8,29 @@
 set -eu -o pipefail
 shopt -s globstar nullglob dotglob
 
-if [ $# -lt 1 ] || [ $# -gt 2 ]; then
-    echo "error when running $0: argument mismatch" 1>&2
-    exit 1
-fi
-
-cloud_provider=$1
-if [ $# -eq 2 ]; then
-    fingerprint=$2
-fi
-
 here="$(dirname "$(readlink -f "$0")")"
 # shellcheck source=bin/common.bash
 source "${here}/common.bash"
+
+cloud_provider="${CK8S_CLOUD_PROVIDER:-}"
+fingerprint="${CK8S_PGP_FP:-}"
+
+while [ "${#}" -gt 1 ]; do
+    case "${1}" in
+    "--cloud-provider") cloud_provider="${2}" ;;
+    "--sops-fingerprint") fingerprint="${2}" ;;
+    *)
+        log_error "ERROR: unknown flag ${1}"
+        exit 1
+        ;;
+    esac
+    shift 2
+done
+
+if [ -z "${cloud_provider}" ]; then
+    log_error "ERROR: either --cloud-provider or the environment variable CK8S_CLOUD_PROVIDER must be set."
+    exit 1
+fi
 
 config_type="default"
 if [ -n "${cloud_provider:-}" ]; then
@@ -41,13 +51,9 @@ if [ -n "${cloud_provider:-}" ]; then
 fi
 
 generate_sops_config() {
-    if [ -z ${fingerprint+x} ]; then
-        if [ -z ${CK8S_PGP_FP+x} ]; then
-            log_error "ERROR: either the <SOPS fingerprint> argument or the env variable CK8S_PGP_FP must be set."
-            exit 1
-        else
-            fingerprint="${CK8S_PGP_FP}"
-        fi
+    if [ -z "${fingerprint}" ]; then
+        log_error "ERROR: either --sops-fingerprint or the environment variable CK8S_PGP_FP must be set."
+        exit 1
     fi
     log_info "Initializing SOPS config with PGP fingerprint: ${fingerprint}"
     sops_config_write_fingerprints "${fingerprint}"


### PR DESCRIPTION
**What this PR does / why we need it**:

This aligns better with compliantkubernetes-apps in two ways:
* ck8s-apps uses `CK8S_CLOUD_PROVIDER`, you will have to set/unset it between runs if you try to use both.
* ck8s-apps uses the term "flavor" to indicate different kinds of the same thing, e.g. cluster size. Not different infrastructure providers.

I've tried to find any lingering mentions of "flavor" and I believe it should all be gone:
```bash
% fgrep -ri --exclude-dir kubespray --exclude-dir .git flavor . 
./docs/citycloud-snippets.md:OS_MASTERS_FLAVOR="" # UUID of master flavor
./docs/citycloud-snippets.md:OS_WORKER_FLAVOR="" # UUID of worker flavor
./docs/citycloud-snippets.md:      -e "s@^flavor_k8s_master = .*@flavor_k8s_master = \"${OS_MASTERS_FLAVOR}\"@" \
./docs/citycloud-snippets.md:      -e "s@^#\?flavor_k8s_node = .*@flavor_k8s_node = \"${OS_WORKER_FLAVOR}\"@" \
./WIP-CHANGELOG.md:- Renamed init argument flavor to cloud_provider.
```

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
Will update documentation if this gets approved.

**Special notes for reviewer**:

**Checklist:**

- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [x] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
