### PR TITLE
pre-commit: Use shellcheck --external-sources

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,7 @@ repos:
   rev: 2.1.4
   hooks:
   - id: shellcheck
+    additional_dependencies: []
     args:
     - "--exclude=SC1091,SC2154"
   - id: markdownlint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,5 +25,5 @@ repos:
   - id: shellcheck
     additional_dependencies: []
     args:
-    - "--exclude=SC1091,SC2154"
+    - "--external-sources"
   - id: markdownlint

--- a/bin/apply-ssh.bash
+++ b/bin/apply-ssh.bash
@@ -6,7 +6,7 @@
 set -eu -o pipefail
 
 here="$(dirname "$(readlink -f "$0")")"
-# shellcheck source=common.bash
+# shellcheck source=bin/common.bash
 source "${here}/common.bash"
 
 log_info "Running playbook authorized_key"

--- a/bin/apply.bash
+++ b/bin/apply.bash
@@ -8,17 +8,16 @@ set -eu -o pipefail
 shopt -s globstar nullglob dotglob
 
 here="$(dirname "$(readlink -f "$0")")"
-# shellcheck source=common.bash
+# shellcheck source=bin/common.bash
 source "${here}/common.bash"
 
 log_info "Creating kubernetes cluster using kubespray"
-# shellcheck disable=SC2154
 pushd "${kubespray_path}"
 
 if [ -z "${CK8S_KUBESPRAY_NO_VENV+x}" ]; then
     log_info "Installing requirements for kubespray"
     python3 -m venv venv
-    # shellcheck source=../kubespray/venv/bin/activate
+    # shellcheck disable=SC1091
     source venv/bin/activate
     pip install -r requirements.txt
 fi

--- a/bin/ck8s-kubespray
+++ b/bin/ck8s-kubespray
@@ -26,7 +26,7 @@ else
     export prefix="${2}"
 fi
 
-# shellcheck source=common.bash
+# shellcheck source=bin/common.bash
 source "${here}/common.bash"
 
 case "${1}" in

--- a/bin/init.bash
+++ b/bin/init.bash
@@ -19,7 +19,7 @@ if [ $# -eq 2 ]; then
 fi
 
 here="$(dirname "$(readlink -f "$0")")"
-# shellcheck source=common.bash
+# shellcheck source=bin/common.bash
 source "${here}/common.bash"
 
 CK8S_CLOUD_PROVIDER=${CK8S_CLOUD_PROVIDER:-""}

--- a/bin/run-playbook.bash
+++ b/bin/run-playbook.bash
@@ -16,7 +16,7 @@ playbook=$1
 shift 1
 
 here="$(dirname "$(readlink -f "$0")")"
-# shellcheck source=common.bash
+# shellcheck source=bin/common.bash
 source "${here}/common.bash"
 
 log_info "Running kubespray playbook ${playbook}"
@@ -25,7 +25,7 @@ pushd "${kubespray_path}"
 if [ -z "${CK8S_KUBESPRAY_NO_VENV+x}" ]; then
     log_info "Installing requirements for kubespray"
     python3 -m venv venv
-    # shellcheck source=../kubespray/venv/bin/activate
+    # shellcheck disable=SC1091
     source venv/bin/activate
     pip install -r requirements.txt
 fi


### PR DESCRIPTION
Using `shellcheck --external-sources` makes shellcheck pick up variables defined in sourced scripts. This allows us to not exclude certain rules. However, they need to be disabled for venv since it doesn't always exist.