### PR TITLE
Release docs, precommit pipeline, and general fixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+# https://editorconfig.org/
+# EditorConfig files are read top to bottom and the most recent rules found take precedence.
+# Properties from matching EditorConfig sections are applied in the order they were read, so properties in closer files take precedence.
+
+# top-most EditorConfig file
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[Makefile]
+intent_style = tab
+tab_width = 4
+
+[*.md]
+# Setting max_line_length=off would use the local editor default.
+# Therefore, set to a high number to allow long lines.
+max_line_length = 10000

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,19 @@
+name: Pre-commit
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    env:
+      SHELLCHECK_VERSION: v0.7.1
+    steps:
+    - name: Install specific version of shellcheck
+      run: wget -qO- "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" | sudo tar -J -xf - --strip-components=1 -C /usr/local/bin/ --no-anchored shellcheck
+      shell: bash
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+    - uses: pre-commit/action@v2.0.0

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - 'release-[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   pre-commit:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Release
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - 'release-[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  release:
+    if: github.event.pull_request.merged == true
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # Fetches all tags
+      - name: Get the version
+        id: get_version
+        run: echo ::set-output name=VERSION::$(git describe --tags --abbrev=0 HEAD)
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.get_version.outputs.VERSION }}
+          release_name: ${{ steps.get_version.outputs.VERSION }}
+          body: |
+            See [CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-kubespray/blob/${{ steps.get_version.outputs.VERSION }}/CHANGELOG.md) for details.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,3 +27,4 @@ repos:
     args:
     - "--external-sources"
   - id: markdownlint
+    exclude: CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
- Compliant Kubernetes changelog
+ Compliant Kubernetes Kubespray changelog
 <!-- BEGIN TOC -->
-- [v2.15.0-ck8s1](#v2.15.0-ck8s1---2021-05-27)
+- [v2.15.0-ck8s1](#v2150-ck8s1---2021-05-27)
 <!-- END TOC -->
 
 -------------------------------------------------
@@ -15,4 +15,3 @@
 ### Changed
 
 ### Removed
-

--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -13,4 +13,3 @@
 ### Added
 
 ### Removed
-

--- a/release/README.md
+++ b/release/README.md
@@ -1,0 +1,173 @@
+# Release process
+
+The releases will have the following version string: `<kubespray-version>-<ck8s-patch>`.
+
+- `<kubespray-version>` is the current version of the kubespray git submodule, e.g. 2.16.0.
+- `<ck8s-patch>` denotes the current version of our wrapper scripts and config with the format `ck8s<number>`, e.g. ck8s1.
+  The `<ck8s-patch>` will always restart at ck8s1 for each new kubespray version, then the number after ck8s will be incremented in case we release a patch.
+
+## New kubespray releases
+
+1. To release a version with an updated kubespray version create a release branch `release-<kubespray-version>` from the main branch.
+
+    ```bash
+    git checkout main
+    git checkout -b release-<kubespray-version>
+    git push -u origin release-<kubespray-version>
+    ```
+
+1. Reset changelog
+
+    ```bash
+    git checkout -b reset-changelog-<kubespray-version>
+    release/reset-changelog.sh <kubespray-version>-<ck8s-patch>
+    ```
+
+    The release script will:
+    - Append what is in `WIP-CHANGELOG.md` to `CHANGELOG.md`
+    - Clear `WIP-CHANGELOG.md`
+    - Create a git commit with message `Reset changelog for release <kubespray-version>-<ck8s-patch>`
+
+    Make sure that the changes only include changes mentioned above, and then push.
+
+    ```bash
+    git diff HEAD~1
+    git push -u origin reset-changelog-<kubespray-version>
+    ```
+
+1. Merge `reset-changelog-<kubespray-version>` into `release-<kubespray-version>` then, into `main` as soon as possible to minimize risk of conflicts
+
+    **NOTE**: The release action will fail since we haven't tagged the release commit.
+    We will do that after QA.
+
+1. Create a `QA-<kubespray-version>` branch and run QA checks on this branch.
+
+    ```bash
+    git checkout release-<kubespray-version>
+    git checkout -b QA-<kubespray-version>
+    git push -u origin QA-<kubespray-version>
+    ```
+
+    **NOTE**: All changes made in QA should be added to `CHANGELOG.md` and **NOT** `WIP-CHANGELOG.md`.
+    Also, make sure to not merge any fixes into `release-<kubespray-version>` on this step.
+
+1. When the QA is finished, create the release tag.
+
+    ```bash
+    git tag v<kubespray-version>-<ck8s-patch>
+    ```
+
+1. Push the tagged commit, create a PR against the release branch and request a review.
+   If there are no changes, create the release manually instead by going to [releases](https://github.com/elastisys/compliantkubernetes-kubespray/releases) and clicking "Draft a new release".
+   Check older releases for how to word it.
+
+    ```bash
+    git push --tags
+    ```
+
+1. Merge it to finalize the release.
+
+    Since the tag is referencing a specific commit hash we need to retain it after the PR (via e.g. fast-forward merge).
+
+    *GitHub currently does not support merging with fast-forward only in PRs.
+    Merge the release PR locally and push it instead.*
+
+    ```bash
+    git checkout release-<kubespray-version>
+    git merge --ff-only QA-<kubespray-version>
+    git push
+    ```
+
+    A [GitHub actions workflow pipeline](/.github/workflows/release.yml) will create a GitHub release from the tag.
+
+1. Merge any fixes from the release branch back to the `main` branch `git cherry-pick` can be used, e.g.
+
+    ```bash
+    git checkout main
+    git checkout -b release-<kubespray-version>-fixes
+    git cherry-pick <fix 1 hash> [<fix 2 hash>..]
+    git push -u origin release-<kubespray-version>-fixes
+    ```
+
+    Create a PR and merge the fixes into main.
+
+## Patch releases
+
+1. Create a new branch based on a release branch and commit the patch commits to it.
+
+    ```bash
+    git checkout release-<kubespray-version>
+    git pull
+    git checkout -b branch_name
+    git cherry-pick [some fix in main]
+    git add -p file-with-some-new-fixes
+    git commit
+    ```
+
+1. Continue from step 2 in the regular release flow.
+    With the exception that `<ck8s-patch>` number should be incremented and that `branch_name` will be used instead of the QA branch.
+
+## While developing
+
+When a feature or change is developed on a branch fill out some human readable
+bullet points in the `WIP-CHANGELOG.md` this will make it easier to track the changes.
+Once the release is done this will be appended to the main changelog.
+
+## Structure
+
+The structure follow the guidelines of [keepachangelog](https://keepachangelog.com/en/1.0.0/).
+
+Changelogs are for humans, not machines. Keep messages in human readable form rather
+than commits or code. Commits or pull requests can off course be linked. Add messages
+as bullet points under one of theese categories:
+
+- Breaking changes
+- Release notes
+- Added
+- Changed
+- Deprecated
+- Removed
+- Fixed
+- Security
+
+When creating a major release a section of `Release highlights` should be added
+on top of the WIP-changelog with a summary of the most important changes.
+
+You can link comments to related pull requests with `PR#pr-number`. Commit ids can be linked
+by just writing that commits short hash or full hash.
+
+## Example changelog
+
+```markdown
+## v2.16.0-ck8s1 - 2020-01-14  (OBS! this line is automatically added by script)
+
+### Breaking changes
+
+* The API endpoint xxxx has been removed.
+
+### Release notes
+
+* To migrate the resources depending on yyyy you have to run this script.
+
+### Added
+
+* Option to add prometheus scrape endpoints
+* Retetion for elasticsearch
+
+### Changed
+
+* Updated grafana version to 6.7.0
+* Changed manifests for deploying ck8sdash into a helm chart PR#120
+
+### Deprecated
+
+* Option to disable OPA with `ENABLE_OPA` variable. Now always true
+
+### Removed
+
+* Curator has been removed. Now retention is configured with ILM.
+
+### Fixed
+
+* bugfix deploying elasticsearch operator 2310e74
+```

--- a/release/reset-changelog.sh
+++ b/release/reset-changelog.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+set -euo pipefail
+
+function usage() {
+    echo "Usage: ${0} VERSION" >&2
+    exit 1
+}
+
+[ ${#} -eq 1 ] || usage
+
+new_version="${1}"
+
+here="$(dirname "$(readlink -f "$0")")"
+root="${here}/.."
+changelog="${root}/CHANGELOG.md"
+wip_changelog="${root}/WIP-CHANGELOG.md"
+
+function file_exists() {
+    if [ ! -f "${1}" ]; then
+        echo "ERROR: ${1} does not exist" >&2
+        exit 1
+    fi
+}
+file_exists "${changelog}"
+file_exists "${wip_changelog}"
+
+# Regex found from https://gist.github.com/rverst/1f0b97da3cbeb7d93f4986df6e8e5695
+function check_version() {
+    if [[ ! $1 =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?$ ]]; then
+        echo "${1} is not a valid version" >&2
+        exit 1
+    fi
+
+    if git rev-parse "v${1}" >/dev/null 2>&1; then
+        echo "v${1} tag already exists" >&2
+        exit 1
+    fi
+}
+
+check_version "${new_version}"
+
+short_version="${new_version//./}"
+DATE=$(date +'%Y-%m-%d')
+
+### Generating new changelog by combining CHANGELOG.md and WIP-CHANGELOG.md ###
+echo "generating new changelog"
+
+# Split Changelog and Table of contents(TOC) into seperate files
+sed -n '/<!-- BEGIN TOC -->/,/<!-- END TOC -->/{ /<!--/d; p }' "${changelog}" > temp-toc.md
+sed '1,/^<!-- END TOC -->$/d' "${changelog}" > temp-cl.md
+
+# Adding version to changelog
+echo -e "## v${new_version} - ${DATE}\n" | cat - "${wip_changelog}" temp-cl.md > temp-cl2.md
+# Adding link to TOC
+echo -e "- [v${new_version}](#v${short_version}---${DATE})" | cat - temp-toc.md > temp-toc2.md
+echo -e "<!-- END TOC -->" >> temp-toc2.md
+echo -e "<!-- BEGIN TOC -->" | cat - temp-toc2.md > temp-toc.md
+echo -e "\n-------------------------------------------------" >> temp-toc.md
+# Creating new changelog
+echo -e "# Compliant Kubernetes changelog" > "${changelog}"
+cat temp-toc.md temp-cl2.md >> "${changelog}"
+rm temp-toc.md temp-toc2.md temp-cl.md temp-cl2.md
+# Clearing WIP-CHANGELOG.md
+true > "${wip_changelog}"
+
+git add "${changelog}" "${wip_changelog}"
+git commit -m "Reset changelog for release v${new_version}"


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds release docs/pipeline, pre-commit pipeline, editor config, and some minor fixes.


**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #90

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

Please go through the release doc thoroughly since I had to adapt it to the version numbers we use in this repo (e.g. v2.16.0-ck8s1). 

**Checklist:**

- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [x] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
