### PR TITLE
config: enabled calico metrics reporting

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,0 +1,9 @@
+### Changed
+
+- enabled calico metrics reporting
+
+### Fixed
+
+### Added
+
+### Removed

--- a/config/common/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml
+++ b/config/common/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml
@@ -93,3 +93,4 @@ audit_policy_custom_rules: |-
       - "RequestReceived"
 podsecuritypolicy_enabled: true
 kubeconfig_localhost: true
+calico_felix_prometheusmetricsenabled: true


### PR DESCRIPTION
**What this PR does / why we need it**: This will enable Calico Felix metrics reporting

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #42 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [x] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
