### PR TITLE
bin: add command to reboot nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,16 @@ When running this command, the SSH keys are applied to each node in the cluster 
 A connection test is performed after each node which has to succeed in order for the playbook to continue.
 If the connection test fails, you may have lost your SSH access to the node; to recover from this, you can set up an SSH connection before running the command and keep it active so that you can change the authorized keys manually.
 
+## Rebooting nodes
+
+You can reboot all nodes that wants to restart (usually to finish installing new packages) by running:
+
+```bash
+./bin/ck8s-kubespray reboot-nodes <prefix> [--extra-vars manual_prompt=true] [<options>]
+```
+
+If you set `--extra-vars manual_prompt=true` then you get a manual prompt before each reboot so you can stop the playbook if you want.
+
 ## Running other kubespray playbooks
 
 With the following command you can run any ansible playbook available in kubespray:

--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -6,4 +6,6 @@
 
 ### Added
 
+- Added new command to reboot nodes in a cluster if necessary
+
 ### Removed

--- a/bin/ck8s-kubespray
+++ b/bin/ck8s-kubespray
@@ -17,6 +17,8 @@ usage() {
     echo "      args: <prefix> <playbook> [<options>]" 1>&2
     echo "  apply-ssh                                   applies SSH keys from a file to a cluster" 1>&2
     echo "      args: <prefix> [<options>]" 1>&2
+    echo "  reboot-nodes                                reboots all nodes in a cluster if needed" 1>&2
+    echo "      args: <prefix> [--extra-vars manual_prompt=true] [<options>]" 1>&2
     exit 1
 }
 
@@ -57,6 +59,13 @@ case "${1}" in
         fi
         shift 2
         "${here}/apply-ssh.bash" "${@}"
+        ;;
+    reboot-nodes)
+        if [ $# -lt 2 ]; then
+            usage
+        fi
+        shift 2
+        "${here}/reboot-nodes.bash" "${@}"
         ;;
     *) usage ;;
 esac

--- a/bin/reboot-nodes.bash
+++ b/bin/reboot-nodes.bash
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# This script will run an ansible playbook.
+# It's not to be executed on its own but rather via `ck8s-kubespray reboot-nodes <prefix>`.
+# Add the variable "manual_prompt = true" for a manual prompt.
+
+set -eu -o pipefail
+
+here="$(dirname "$(readlink -f "$0")")"
+# shellcheck source=bin/common.bash
+source "${here}/common.bash"
+
+log_info "Running playbook reboot_nodes"
+pushd "${here}/../playbooks"
+
+ansible-playbook -i "${config[inventory_file]}" reboot_nodes.yml -b "$@"
+
+popd
+
+log_info "Playbook ran successfully!"

--- a/playbooks/reboot_nodes.yml
+++ b/playbooks/reboot_nodes.yml
@@ -39,19 +39,17 @@
     # If both are set then a redundant wait is run.
 
     - name: Waiting for the machine to come back (ansible_host)
-      local_action: wait_for host={{ ansible_host }} state=started port=22 delay=30
+      local_action: wait_for host={{ ansible_host }} state=started port=22 delay=30 timeout=600
       become: no
       register: machine_up
-      ignore_errors: yes
       when:
       - ansible_host != "localhost"
       - reboot_required_file.stat.exists
 
     - name: Waiting for the machine to come back (ansible_ssh_host)
-      local_action: wait_for host={{ ansible_ssh_host }} state=started port=22 delay=30
+      local_action: wait_for host={{ ansible_ssh_host }} state=started port=22 delay=30 timeout=600
       become: no
       register: machine_up
-      ignore_errors: yes
       when:
       - ansible_ssh_host != "localhost"
       - reboot_required_file.stat.exists

--- a/playbooks/reboot_nodes.yml
+++ b/playbooks/reboot_nodes.yml
@@ -1,0 +1,94 @@
+- hosts: k8s_cluster
+  serial: 1
+  order: reverse_inventory
+  tasks:
+
+    - name: Check if reboot is required
+      stat:
+        path: /var/run/reboot-required
+      register: reboot_required_file
+
+    # In a normal play, the pause action is only executed once, not once-per-host.
+    # In this case, we really want to force the once-per-host thing.
+    - name: Prompt for rebooting
+      pause:
+        prompt: "Press ENTER to reboot {{ item }} now, or Ctrl+C to abort."
+      # We need to check for the existence of 'reboot_required_file' first because play_hosts also
+      # include hosts that have failed. When a host has failed, it stops executing and thus doesn't
+      # have 'reboot_required_file'. And if we try to access 'stat', boom! failure. We don't want that.
+      when: "manual_prompt | default(false) | bool and 'reboot_required_file' in hostvars[item] and hostvars[item]['reboot_required_file'].stat.exists"
+      with_items: "{{ play_hosts }}"
+
+    - name: hostname
+      shell: echo $HOSTNAME
+      args:
+        executable: /bin/bash
+      register: hostname
+      when: reboot_required_file.stat.exists
+
+    - name: Rebooting machine
+      shell: sleep 2 && shutdown -r now "Ansible updates triggered"
+      async: 1
+      poll: 0
+      ignore_errors: true
+      when: reboot_required_file.stat.exists
+
+    # Either ansible_host or ansible_ssh_host should be set to the target IP,
+    # but the other is probably set to localhost when running a local_action.
+    # So we need to pick the correct one.
+    # If both are set then a redundant wait is run.
+
+    - name: Waiting for the machine to come back (ansible_host)
+      local_action: wait_for host={{ ansible_host }} state=started port=22 delay=30
+      become: no
+      register: machine_up
+      ignore_errors: yes
+      when:
+      - ansible_host != "localhost"
+      - reboot_required_file.stat.exists
+
+    - name: Waiting for the machine to come back (ansible_ssh_host)
+      local_action: wait_for host={{ ansible_ssh_host }} state=started port=22 delay=30
+      become: no
+      register: machine_up
+      ignore_errors: yes
+      when:
+      - ansible_ssh_host != "localhost"
+      - reboot_required_file.stat.exists
+
+    - name: wait for kubectl access
+      command: kubectl get nodes --kubeconfig /etc/kubernetes/admin.conf
+      delegate_to: "{{groups['kube_control_plane'][0]}}"
+      register: kubectl_up
+      until: kubectl_up.rc == 0
+      retries: 30
+      delay: 3
+      when: reboot_required_file.stat.exists
+
+    - name: get time
+      debug:
+        var=ansible_date_time.iso8601
+      register: time
+      when: reboot_required_file.stat.exists
+
+    - name: Wait for node to start posting heartbeats
+      ansible.builtin.shell: $([[ {{time['ansible_date_time.iso8601']}} < $(kubectl get node {{hostname.stdout}} -o jsonpath='{.status.conditions[?(@.type=="Ready")].lastHeartbeatTime}' --kubeconfig /etc/kubernetes/admin.conf) ]])
+      delegate_to: "{{groups['kube_control_plane'][0]}}"
+      args:
+        executable: /bin/bash
+      register: kubelet_heartbeat
+      until: kubelet_heartbeat.rc == 0
+      retries: 30
+      delay: 3
+      when: reboot_required_file.stat.exists
+
+    - name: Wait for node to be ready
+      ansible.builtin.shell: $([[ $(kubectl get node {{hostname.stdout}} -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' --kubeconfig /etc/kubernetes/admin.conf) == "True" ]])
+      delegate_to: "{{groups['kube_control_plane'][0]}}"
+      args:
+        executable: /bin/bash
+      register: kubelet_ready
+      until: kubelet_ready.rc == 0
+      retries: 30
+      delay: 3
+      when: reboot_required_file.stat.exists


### PR DESCRIPTION
**What this PR does / why we need it**: This adds a command/playbook to reboot all nodes in a cluster if necessary.

I'm not sure I like how all of the tasks are written, so feel free to suggest alternate implementations.

Based on https://github.com/savoirfairelinux/ansible-reboot-if-needed

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [ ] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
