### PR TITLE
docs: update 2.15 -> 2.16 migration doc

### DIFF
--- a/migration/v2.15.0-ck8s1-v2.16.0-ck8s1/upgrade-cluster.md
+++ b/migration/v2.15.0-ck8s1-v2.16.0-ck8s1/upgrade-cluster.md
@@ -10,7 +10,17 @@
     - If you are not using dynamic inventories (e.g. for Exoscale), change the following groups in your inventory file (`inventory.ini`): kube-master to kube_control_plane, kube-node to kube_node, and k8s-cluster to k8s_cluster.
     See `config/inventory.ini` for an example.
 
+    - If you are using dynamic inventories, you may have to run `terraform apply` to update your terraform state with new metadata about these new group names.
+
     - Update any folders inside `group_vars/` to match the new names for the groups mentioned above (e.g. change k8s-cluster to k8s_cluster)
+
+1. SSH into each node and run the following:
+
+    ```bash
+    sudo /bin/apt-get -o "Dpkg::Options::=--force-confdef" -o "Dpkg::Options::=--force-confold" install 'containerd.io=1.4.4-1' 'docker-ce-cli=5:19.03.15~3-0~ubuntu-focal' 'docker-ce=5:19.03.15~3-0~ubuntu-focal'
+    ```
+
+    If nothing gets downgraded on the first node you try this on, you can skip doing it on the other ones in the cluster.
 
 1. Upgrade you cluster by running `./bin/ck8s-kubespray run-playbook sc upgrade-cluster.yml -b`.
     Note that this will also upgrade Kubernetes to v1.20.7 (unless you have another version pinned).


### PR DESCRIPTION
**What this PR does / why we need it**: Updates the 2.15 -> 2.16 migration doc with some necessary steps. Since this change won't be on the release tag, the person doing the upgrade should be referred to the document on the main branch instead.

**Which issue this PR fixes**: none

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [X] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [X] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
