### PR TITLE
bin: flavor is used to pick group folder to copy

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,6 +1,7 @@
 ### Changed
 
 - enabled calico metrics reporting
+- init script uses $flavor automatically to choose the group folder to copy to the config folder
 
 ### Fixed
 

--- a/bin/init.bash
+++ b/bin/init.bash
@@ -64,17 +64,7 @@ mkdir -p "${config_path}"
 # Copy default group_vars
 cp -r "${config_defaults_path}/common/group_vars" "${config_path}/"
 
-if [[ "${flavor}" == "default" ]]; then
-  cp -r "${config_defaults_path}/default/group_vars" "${config_path}/"
-elif [[ "${flavor}" == "gcp" ]]; then
-  cp -r "${config_defaults_path}/gcp/group_vars" "${config_path}/"
-elif [[ "${flavor}" == "aws" ]]; then
-  cp -r "${config_defaults_path}/aws/group_vars" "${config_path}/"
-elif [[ "${flavor}" == "openstack" ]]; then
-  cp -r "${config_defaults_path}/openstack/group_vars" "${config_path}/"
-elif [[ "${flavor}" == "vsphere" ]]; then
-  cp -r "${config_defaults_path}/vsphere/group_vars" "${config_path}/"
-fi
+cp -r --dereference "${config_defaults_path}/${flavor}/group_vars" "${config_path}/"
 
 # Copy inventory.ini
 if [[ ! -f "${config[inventory_file]}" ]]; then


### PR DESCRIPTION
**What this PR does / why we need it**:
Use the flavor variable to choose the group_vars to copy more cleanly.

**Which issue this PR fixes**:
fixes #38

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [X] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [x] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
