### PR TITLE
apps: Scripts and instructions how to remove rook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
 
 ### Added
 
+- Added scripts and instructions for removing Rook.
+
 ### Removed
 
 -------------------------------------------------

--- a/rook/remove-rook.sh
+++ b/rook/remove-rook.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+here="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+
+namespace="rook-ceph"
+release_name="rook-ceph"
+
+# Remove toolbox
+kubectl --namespace "${namespace}" delete -f "${here}/toolbox-deploy.yaml"
+
+# Remove ceph cluster
+kubectl -n "${namespace}" patch cephclusters.ceph.rook.io "${namespace}" -p '{"metadata":{"finalizers": []}}' --type=merge
+kubectl --namespace "${namespace}" delete -f "${here}/cluster.yaml"
+
+# Remove storageclass
+kubectl --namespace "${namespace}" delete -f "${here}/storageclass.yaml"
+
+# Remove rook operator and namespace
+helm uninstall --namespace "${namespace}" "${release_name}"
+kubectl delete namespace "${namespace}"

--- a/rook/zap-disk
+++ b/rook/zap-disk
@@ -1,0 +1,32 @@
+# This script should run on the working nodes of the cluster.
+# DO NOT RUN THIS JUST AS IT IS.
+# https://github.com/rook/rook/blob/master/Documentation/ceph-teardown.md#zapping-devices
+
+# Zap the disk to a fresh, usable state (zap-all is important, b/c MBR has to be clean)
+: "${DISK:?Missing DISK}"
+
+# You will have to run this step for all disks.
+sudo sgdisk --zap-all $DISK
+
+# Clean hdds with dd
+sudo dd if=/dev/zero of="$DISK" bs=1M count=100 oflag=direct,dsync
+
+# Clean disks such as ssd with blkdiscard instead of dd
+#sudo blkdiscard $DISK
+
+# These steps only have to be run once on each node
+# If rook sets up osds using ceph-volume, teardown leaves some devices mapped that lock the disks.
+ls /dev/mapper/ceph-* | sudo xargs -I% -- dmsetup remove %
+
+# ceph-volume setup can leave ceph-<UUID> directories in /dev and /dev/mapper (unnecessary clutter)
+sudo rm -rf /dev/ceph-*
+sudo rm -rf /dev/mapper/ceph--*
+
+# Inform the OS of partition table changes
+sudo partprobe $DISK
+
+sudo rm -rf /var/lib/rook/
+
+# Ensure that everything is wiped
+lsblk
+ls /var/lib/rook

--- a/rook/zap-disk.sh
+++ b/rook/zap-disk.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -e -o pipefail
+
+here="$(dirname "$(readlink -f "$0")")"
+
+if [[ "$#" -lt 1 || "$#" -gt 2 ]]; then
+    echo "${0} <host ip> [sdb]"
+    exit 1
+fi
+
+HOST_IP=${1}
+#Check that it is a valid IP
+if [[ ! (${HOST_IP} =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$) ]]; then
+  echo "ERROR: host ip ${HOST_IP} is not a IP address."
+  exit 1
+fi
+
+#Set disk
+if [[ "$#" -eq 1 ]]; then
+    echo -n "Enter disk to wipe (Continue for default: sdb):"
+    read -r disk
+    if [[ ${reply} -eq "" ]]; then
+        DISK=sdb
+    else
+        DISK=${disk}
+    fi
+    echo ""
+else
+    DISK=${2}
+fi
+
+echo "WARNING!"
+echo "This script will wipe the disk /dev/${DISK} on machine ${HOST_IP}"
+echo -n "Are you sure you want to continue (y/N): "
+read -r reply
+if [[ ${reply} != "y" ]]; then
+    echo  "Exited"
+    exit 1
+fi
+
+echo "Staring to wipe disk"
+ssh ubuntu@"${HOST_IP}" DISK="/dev/${DISK}" 'bash -s' < "${here}/zap-disk"


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds scripts and instructions how to remove Rook. Needed for [#299](https://github.com/elastisys/ck8s-ops/issues/299)

**Which issue this PR fixes** : 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [x] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
