### PR TITLE
config: update openstack config to use external cloud controller

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - enabled calico metrics reporting
 - init script uses $flavor automatically to choose the group folder to copy to the config folder
+- Changed default openstack config to use the external cloud controller
 
 ### Fixed
 

--- a/config/openstack/group_vars/k8s_cluster/ck8s-k8s-cluster-openstack.yaml
+++ b/config/openstack/group_vars/k8s_cluster/ck8s-k8s-cluster-openstack.yaml
@@ -1,4 +1,34 @@
 etcd_kubeadm_enabled: true
 
-cloud_provider: openstack
+cloud_provider: external
+external_cloud_provider: openstack
 calico_mtu: 1480
+
+external_openstack_cloud_controller_extra_args:
+  # Must be different for every cluster in the same openstack project
+  cluster-name: "set-me"
+
+# cinder_csi_enabled: true
+# persistent_volumes_enabled: true
+# openstack_blockstorage_ignore_volume_az: true
+
+# external_openstack_lbaas_network_id: "Neutron network ID to create LBaaS VIP"
+# external_openstack_lbaas_subnet_id: "Neutron subnet ID to get IP from"
+# external_openstack_lbaas_floating_network_id: "Neutron floating network ID to create LBaaS VIP"
+# external_openstack_lbaas_floating_subnet_id: "Neutron subnet ID to get floating IP from"
+# external_openstack_lbaas_method: "ROUND_ROBIN"
+# external_openstack_lbaas_provider: "octavia"
+# external_openstack_lbaas_use_octavia: true
+# external_openstack_lbaas_create_monitor: true
+# external_openstack_lbaas_monitor_delay: "1m"
+# external_openstack_lbaas_monitor_timeout: "30s"
+# external_openstack_lbaas_monitor_max_retries: "3"
+# external_openstack_lbaas_manage_security_groups: false
+# external_openstack_lbaas_internal_lb: false
+# external_openstack_network_ipv6_disabled: false
+# external_openstack_network_internal_networks:
+#   - ""
+# external_openstack_network_public_networks:
+#   - "ext-net"
+# external_openstack_metadata_search_order: "configDrive,metadataService"
+# supplementary_addresses_in_ssl_keys: []


### PR DESCRIPTION
**What this PR does / why we need it**: Updates the openstack config to use the external cloud controller.

**Which issue this PR fixes**: fixes #91

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**: Someone who's familiar with the config, tell me if some more config should be added to the defaults.

**Checklist:**

- [X] Proper commit message prefix on all commits
- [X] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes) https://github.com/elastisys/compliantkubernetes/pull/162
- Is this changeset backwards compatible for existing clusters? Applying:
  - [ ] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
