### PR TITLE
config: Update Openstack config to use Cinder by default

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -10,5 +10,6 @@
 
 - Added new command to reboot nodes in a cluster if necessary
 - resource requests for rook containers [#105](https://github.com/elastisys/compliantkubernetes-kubespray/pull/105)
+- Added configuration for Openstack to use Cinder CSI by default with volume expansion enabled.
 
 ### Removed

--- a/config/openstack/group_vars/k8s_cluster/ck8s-k8s-cluster-openstack.yaml
+++ b/config/openstack/group_vars/k8s_cluster/ck8s-k8s-cluster-openstack.yaml
@@ -8,9 +8,17 @@ external_openstack_cloud_controller_extra_args:
   # Must be different for every cluster in the same openstack project
   cluster-name: "set-me"
 
-# cinder_csi_enabled: true
-# persistent_volumes_enabled: true
-# openstack_blockstorage_ignore_volume_az: true
+cinder_csi_enabled: true
+persistent_volumes_enabled: true
+expand_persistent_volumes: true
+openstack_blockstorage_ignore_volume_az: true
+
+storage_classes:
+  - name: cinder-csi
+    is_default: true
+    parameters:
+      allowVolumeExpansion: true
+      availability: nova
 
 # external_openstack_lbaas_network_id: "Neutron network ID to create LBaaS VIP"
 # external_openstack_lbaas_subnet_id: "Neutron subnet ID to get IP from"


### PR DESCRIPTION
**What this PR does / why we need it**:
This sets Cinder CSI as the default storage provider on Openstack while enabling volume expansion on new clusters.

**Which issue this PR fixes**: 
fixes #110 

**Public facing documentation PR** *(if applicable)*
https://github.com/elastisys/compliantkubernetes/pull/177

**Special notes for reviewer**:

**Checklist:**

- [x] Proper commit message prefix on all commits
- [x] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [x] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
