### PR TITLE
docs: Added known issue for rebooting node script

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ You can reboot all nodes that wants to restart (usually to finish installing new
 
 If you set `--extra-vars manual_prompt=true` then you get a manual prompt before each reboot so you can stop the playbook if you want.
 
+### Known issues
+
+- The script may fail with the message `error while evaluating conditional (kubelet_heartbeat.rc == 0): 'dict object' has no attribute 'rc'`
+  - In such situations just rerun the script. It will skip the check for that node, so check that it is up and running manually afterwards.
+
 ## Running other kubespray playbooks
 
 With the following command you can run any ansible playbook available in kubespray:

--- a/bin/reboot-nodes.bash
+++ b/bin/reboot-nodes.bash
@@ -3,6 +3,7 @@
 # This script will run an ansible playbook.
 # It's not to be executed on its own but rather via `ck8s-kubespray reboot-nodes <prefix>`.
 # Add the variable "manual_prompt = true" for a manual prompt.
+# The script may fail and in such situations rerun the script.
 
 set -eu -o pipefail
 

--- a/playbooks/reboot_nodes.yml
+++ b/playbooks/reboot_nodes.yml
@@ -76,7 +76,7 @@
         executable: /bin/bash
       register: kubelet_heartbeat
       until: kubelet_heartbeat.rc == 0
-      retries: 30
+      retries: 60
       delay: 3
       when: reboot_required_file.stat.exists
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Added a note that there is a known issue for the reboot script. I could not recreate the bug, i tried multiple ways to make the step fail but the error was never the same. 

The error occurs if the `kubelet_heartbeat` is not registered in the playbook, which is unclear why it happens. 

I also increased the number of retries, as it may be because of to few retries.

**Which issue this PR fixes**:
fixes #112 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [x] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
