### PR TITLE
docs: Update release document to include user-facing release notes

### DIFF
--- a/release/README.md
+++ b/release/README.md
@@ -91,6 +91,14 @@ The releases will have the following version string: `<kubespray-version>-<ck8s-
 
     Create a PR and merge the fixes into main.
 
+1. Update public release notes.
+
+    When a released is published the public [user-facing release notes](https://github.com/elastisys/compliantkubernetes/blob/main/docs/release-notes.md) needs to be updated. The new release needs to be added and the list can be trimmed down to only include the supported versions.
+
+    Add bullet points of major changes within the cluster that affects the user as defined [here](https://compliantkubernetes.io/user-guide/). This includes any change within the cluster that may impact the user experience, for example new or updated feature, or the deprecation of features.
+
+    Finish it of with one bullet point regarding the overall changes of the release in regards to updates, fixes, or other improvements.
+
 ## Patch releases
 
 1. Create a new branch based on a release branch and commit the patch commits to it.


### PR DESCRIPTION
**What this PR does / why we need it**:
This updates the release document to include updating the user-facing release notes.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes elastisys/compliantkubernetes#148

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [x] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
