### PR TITLE
bin: add drain to reboot script

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ You can reboot all nodes that wants to restart (usually to finish installing new
 
 If you set `--extra-vars manual_prompt=true` then you get a manual prompt before each reboot so you can stop the playbook if you want.
 
+Note that this playbook requires you to use ansible version >= 2.10.
+
 ### Known issues
 
 - The script may fail with the message `error while evaluating conditional (kubelet_heartbeat.rc == 0): 'dict object' has no attribute 'rc'`

--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,0 +1,3 @@
+### Changed
+
+- The reboot playbook now also drains the nodes before restarting them.

--- a/playbooks/reboot_nodes.yml
+++ b/playbooks/reboot_nodes.yml
@@ -3,6 +3,12 @@
   order: reverse_inventory
   tasks:
 
+    - name: Check that ansible version is >= 2.10.0
+      assert:
+        that:
+        - ansible_version.full is version('2.10.0', '>=')
+        fail_msg: "You need to have an ansible version >= 2.10.0"
+
     - name: Check if reboot is required
       stat:
         path: /var/run/reboot-required
@@ -24,6 +30,11 @@
       args:
         executable: /bin/bash
       register: hostname
+      when: reboot_required_file.stat.exists
+
+    - name: drain node
+      command: kubectl drain {{hostname.stdout}} --ignore-daemonsets=true --delete-emptydir-data=true --force=true --kubeconfig /etc/kubernetes/admin.conf
+      delegate_to: "{{groups['kube_control_plane'][0]}}"
       when: reboot_required_file.stat.exists
 
     - name: Rebooting machine
@@ -89,4 +100,9 @@
       until: kubelet_ready.rc == 0
       retries: 30
       delay: 3
+      when: reboot_required_file.stat.exists
+
+    - name: uncordon node
+      command: kubectl uncordon {{hostname.stdout}} --kubeconfig /etc/kubernetes/admin.conf
+      delegate_to: "{{groups['kube_control_plane'][0]}}"
       when: reboot_required_file.stat.exists


### PR DESCRIPTION
**What this PR does / why we need it**: The reboot script now drains each node before rebooting them.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [ ] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
