### PR TITLE
apps:rook add provisioner and plugin tolerations for tainted nodes

### DIFF
--- a/rook/operator-values.yaml
+++ b/rook/operator-values.yaml
@@ -1,5 +1,13 @@
 csi:
   enableCephfsDriver: false
+  #provisionerTolerations:
+  #  - key: "nodeType"
+  #    operator: Exists
+  #    effect: NoSchedule
+  #pluginTolerations:
+  #  - key: "nodeType"
+  #    operator: Exists
+  #    effect: NoSchedule
   csiRBDProvisionerResource: |
    - name : csi-provisioner
      resource:


### PR DESCRIPTION
**What this PR does / why we need it**:  I have added in commented lines the "provisionerTolerations" and "pluginTolerations". These are needed for Exoscale and other cloud providers where we use rook-ceph. It is needed to be able to schedule the csi-rbdplugin pods on nodes that are tainted and be able to mount volumes on those tainted nodes.
Without this, the tainted nodes will not have the csi-rbdplugin pods running on them, and without that the nodes will fail to mount volumes with the following error:

_FailedMount  9m25s (x461 over 15h)  kubelet  MountVolume.MountDevice failed for volume "pvc-9e7ec0da-d52d-46b8-bd74-e5262286cb0d" : kubernetes.io/csi: attacher.MountDevice failed to create newCsiDriverClient: driver name rook-ceph.rbd.csi.ceph.com not found in the list of registered CSI drivers_


**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [x] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
