### PR TITLE
all: update kubespray to v2.17.1

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,3 +1,5 @@
 ### Changed
 
 - The reboot playbook now also drains the nodes before restarting them.
+- Upgraded kubespray from v2.17.0 to v2.17.1.
+    Includes upgrade to Kubernetes v1.21.6.

--- a/migration/v2.17.0-ck8s1-v2.17.1-ck8s1/upgrade-cluster.md
+++ b/migration/v2.17.0-ck8s1-v2.17.1-ck8s1/upgrade-cluster.md
@@ -1,0 +1,11 @@
+# Upgrade v2.17.0-ck8s1 to v2.17.1-ck8s1
+
+1. Checkout the new release: `git checkout v2.17.1-ck8s1`
+
+1. Update the kubespray submodule: `git submodule update --init --recursive`
+
+1. Upgrade your cluster by running `./bin/ck8s-kubespray run-playbook sc upgrade-cluster.yml -b`.
+    Note that this will also upgrade Kubernetes to v1.21.6 (unless you have another version pinned).
+
+1. Upgrade your cluster by running `./bin/ck8s-kubespray run-playbook wc upgrade-cluster.yml -b`.
+    Note that this will also upgrade Kubernetes to v1.21.6 (unless you have another version pinned).


### PR DESCRIPTION
**What this PR does / why we need it**: Upgrade to kubespray v2.17.1

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**: I added migration steps for 2.17.0 -> 2.17.1, but I'm gonna try if 2.16.0 -> 2.17.1 is possible directly. If so, I'll change the migration docs during the QA process.

**Checklist:**

- [X] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [ ] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
