### PR TITLE
apps: Add owned by operator label to rook namespace

### DIFF
--- a/rook/deploy-rook.sh
+++ b/rook/deploy-rook.sh
@@ -13,6 +13,7 @@ chart_version="v1.5.3"
 
 # Install rook operator
 kubectl create namespace "${namespace}" --dry-run -o yaml | kubectl apply -f -
+kubectl label namespace "${namespace}" owner=operator
 helm upgrade --install --namespace "${namespace}" "${release_name}" "${chart}" \
   --version "${chart_version}" --values "${here}/operator-values.yaml" --wait
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds `owner=operator` label to rook-ceph namespace to exclude it from OPA policies.

**Which issue this PR fixes**: 
fixes elastisys/compliantkubernetes-apps#620

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [x] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
