### PR TITLE
bin: add prompt and checks for openstack credentials

### DIFF
--- a/bin/apply.bash
+++ b/bin/apply.bash
@@ -11,6 +11,8 @@ here="$(dirname "$(readlink -f "$0")")"
 # shellcheck source=bin/common.bash
 source "${here}/common.bash"
 
+check_openstack_credentials
+
 log_info "Creating kubernetes cluster using kubespray"
 pushd "${kubespray_path}"
 

--- a/bin/common.bash
+++ b/bin/common.bash
@@ -46,6 +46,10 @@ log_info() {
     echo -e "[\e[34mck8s\e[0m] ${*}" 1>&2
 }
 
+log_info_no_newline() {
+    echo -e -n "[\e[34mck8s\e[0m] ${*}" 1>&2
+}
+
 log_warning() {
     echo -e "[\e[33mck8s\e[0m] ${*}" 1>&2
 }
@@ -174,4 +178,53 @@ sops_exec_file_no_fifo() {
     sops_decrypt_verify "${1}"
 
     sops --config "${sops_config}" exec-file --no-fifo "${1}" "${2}"
+}
+
+# Checks the current openstack env variables to see if anything is missing.
+# The user is then show what is set and prompted if they want to proceed or not.
+# The user can still proceed if nothing is set, to allow for other types of cloud providers.
+check_openstack_credentials() {
+    log_info "Checking for openstack user or openstack application credentials"
+
+    if [ -n "${OS_USERNAME:-}" ] && [ -n "${OS_APPLICATION_CREDENTIAL_NAME:-}" ]; then
+        log_error "ERROR: Both OS_USERNAME and OS_APPLICATION_CREDENTIAL_NAME are set."
+        log_error "Unset env vars for either the openstack user or the openstack application credentials."
+        log_error "Unset openstack user: \"unset OS_USERNAME OS_PASSWORD\""
+        log_error "Unset openstack application credentials: \"unset OS_APPLICATION_CREDENTIAL_NAME OS_APPLICATION_CREDENTIAL_ID OS_APPLICATION_CREDENTIAL_SECRET\""
+        exit 1
+    elif [ -n "${OS_APPLICATION_CREDENTIAL_NAME:-}" ]; then
+        if [ -n "${OS_APPLICATION_CREDENTIAL_ID:-}" ] && [ -n "${OS_APPLICATION_CREDENTIAL_SECRET:-}" ]; then
+            log_info "Openstack application credentials found"
+            log_info "OS_APPLICATION_CREDENTIAL_NAME is: ${OS_APPLICATION_CREDENTIAL_NAME}"
+            log_info "OS_APPLICATION_CREDENTIAL_ID is not empty (check contents by running \"echo \$OS_APPLICATION_CREDENTIAL_ID\")"
+            log_info "OS_APPLICATION_CREDENTIAL_SECRET is not empty (check contents by running \"echo \$OS_APPLICATION_CREDENTIAL_SECRET\")"
+        elif [ -n "${OS_APPLICATION_CREDENTIAL_ID:-}" ]; then
+            log_error "ERROR: OS_APPLICATION_CREDENTIAL_NAME and OS_APPLICATION_CREDENTIAL_ID is set but OS_APPLICATION_CREDENTIAL_SECRET is emppty!"
+            exit 1
+        elif [ -n "${OS_APPLICATION_CREDENTIAL_SECRET:-}" ]; then
+            log_error "ERROR: OS_APPLICATION_CREDENTIAL_NAME and OS_APPLICATION_CREDENTIAL_SECRET is set but OS_APPLICATION_CREDENTIAL_ID is emppty!"
+            exit 1
+        else
+            log_error "ERROR: OS_APPLICATION_CREDENTIAL_NAME is set but OS_APPLICATION_CREDENTIAL_ID and OS_APPLICATION_CREDENTIAL_SECRET is emppty!"
+            exit 1
+        fi
+    elif [ -n "${OS_USERNAME:-}" ]; then
+        if [ -n "${OS_PASSWORD:-}" ]; then
+            log_info "Openstack user found"
+            log_info "OS_USERNAME is: ${OS_USERNAME}"
+            log_info "OS_PASSWORD is not empty (check contents by running \"echo \$OS_PASSWORD\")"
+        else
+            log_error "ERROR: OS_USERNAME is set but OS_PASSWORD is empty!"
+            exit 1
+        fi
+    else
+        log_warning "Warning: No openstack user or openstack application credentials found."
+        log_warning "If you are not running on openstack, then you can safely ignore this."
+    fi
+
+    log_info_no_newline "Proceed with the current credentials [y/N]: "
+    read -r reply
+    if [[ "${reply}" != "y" ]]; then
+        exit 1
+    fi
 }

--- a/bin/run-playbook.bash
+++ b/bin/run-playbook.bash
@@ -19,6 +19,8 @@ here="$(dirname "$(readlink -f "$0")")"
 # shellcheck source=bin/common.bash
 source "${here}/common.bash"
 
+check_openstack_credentials
+
 log_info "Running kubespray playbook ${playbook}"
 pushd "${kubespray_path}"
 


### PR DESCRIPTION
**What this PR does / why we need it**: Adds some checks for openstack credentials and a prompt for the user to hopefully catch when a user would accidentally use the wrong credentials.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #146 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:
Some examples:

No credentials set:
![no-creds](https://user-images.githubusercontent.com/58632240/146925582-d467d4ca-9cf1-44d2-b512-801d498b4b58.png)

`OS_USERNAME` and `OS_PASSWORD` are set:
![os-user](https://user-images.githubusercontent.com/58632240/146925605-f9885517-f0f4-4bdf-9392-8509369b6861.png)

`OS_APPLICATION_CREDENTIAL_SECRET` is missing:
![no-appsecret](https://user-images.githubusercontent.com/58632240/146925622-520142aa-112e-4a53-86fd-796b970bf13e.png)

Both openstack user and openstack application credentials are set:
![both-creds](https://user-images.githubusercontent.com/58632240/146925639-12eb8733-d5ed-4b38-b431-e1d0ae6897ec.png)

**Checklist:**


- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [x] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
