### PR TITLE
docs: updated the migration docs

### DIFF
--- a/migration/v2.16.0-ck8s1-v2.17.x-ck8s1/upgrade-cluster.md
+++ b/migration/v2.16.0-ck8s1-v2.17.x-ck8s1/upgrade-cluster.md
@@ -4,6 +4,8 @@
 
 1. Update the kubespray submodule: `git submodule update --init --recursive`
 
+1. add `calico_felix_prometheusmetricsenabled: true` at the end of both `sc-config/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml` and `wc-config/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml`
+
 1. Upgrade your cluster by running `./bin/ck8s-kubespray run-playbook sc upgrade-cluster.yml -b`.
 
 1. Upgrade your cluster by running `./bin/ck8s-kubespray run-playbook wc upgrade-cluster.yml -b`.


### PR DESCRIPTION
**What this PR does / why we need it**: to update the migration docs on how to enable calico felix metrics

**Checklist:**

- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [ ] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
