### PR TITLE
ansible: docker prune

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,0 +1,11 @@
+### Changed
+
+### Fixed
+
+### Added
+
+- Added ansible config
+- Playbook to remove unused docker resources (images, ...)
+- Lowered the threshold for garbage collection of unused images.
+
+### Removed

--- a/bin/ck8s-kubespray
+++ b/bin/ck8s-kubespray
@@ -19,6 +19,8 @@ usage() {
     echo "      args: <prefix> [<options>]" 1>&2
     echo "  reboot-nodes                                reboots all nodes in a cluster if needed" 1>&2
     echo "      args: <prefix> [--extra-vars manual_prompt=true] [<options>]" 1>&2
+    echo "  prune-docker                                removes unsued docker resoruces on all nodes" 1>&2
+    echo "      args: <prefix> [<options>]" 1>&2
     exit 1
 }
 
@@ -66,6 +68,13 @@ case "${1}" in
         fi
         shift 2
         "${here}/reboot-nodes.bash" "${@}"
+        ;;
+    prune-docker)
+        if [ $# -lt 2 ]; then
+            usage
+        fi
+        shift 2
+        "${here}/prune-docker.bash" "${@}"
         ;;
     *) usage ;;
 esac

--- a/bin/prune-docker.bash
+++ b/bin/prune-docker.bash
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# This script will run an ansible playbook.
+# It's not to be executed on its own but rather via `ck8s-kubespray prune-docker <prefix>`.
+
+set -eu -o pipefail
+
+here="$(dirname "$(readlink -f "$0")")"
+# shellcheck source=bin/common.bash
+source "${here}/common.bash"
+
+log_info "Running playbook prune_docker"
+pushd "${here}/../playbooks"
+
+ansible-playbook -i "${config[inventory_file]}" prune_docker.yml -b "$@"
+
+popd
+
+log_info "Playbook ran successfully!"

--- a/config/common/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml
+++ b/config/common/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml
@@ -94,3 +94,7 @@ audit_policy_custom_rules: |-
 podsecuritypolicy_enabled: true
 kubeconfig_localhost: true
 calico_felix_prometheusmetricsenabled: true
+
+kubelet_config_extra_args:
+  imageGCHighThresholdPercent: 75
+  imageGCLowThresholdPercent: 70

--- a/docs/adding-kubelet-args-to-existing-environment.md
+++ b/docs/adding-kubelet-args-to-existing-environment.md
@@ -1,0 +1,22 @@
+# Adding kubelet variables to existing environment
+
+Start with switching to the correct compliantkubernetes-kubespray release.
+Add the kubelet arguments in `sc-config/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml` and `wc-config/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml`.
+
+Possible arguments to give kubelet can be found here: [kubelet arguments](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/#kubelet-config-k8s-io-v1beta1-KubeletConfiguration).
+
+The following is a example of changing when to garbage collect unused images
+
+```yaml
+...
+kubelet_config_extra_args:
+  imageGCHighThresholdPercent: 75
+  imageGCLowThresholdPercent: 70
+```
+
+To apply the change run the following ck8s-kubespray command:
+
+```bash
+./bin/ck8s-kubespray apply sc --tags=node
+./bin/ck8s-kubespray apply wc --tags=node
+```

--- a/migration/v2.18.0-ck8s1-v2.19.x-ck8s1/upgrade-cluster.md
+++ b/migration/v2.18.0-ck8s1-v2.19.x-ck8s1/upgrade-cluster.md
@@ -1,0 +1,17 @@
+# Upgrade v2.18.0-ck8s1 to v2.19.x-ck8s1
+
+1. Checkout the new release: `git checkout v2.19.x-ck8s1`
+
+1. Update the kubespray submodule: `git submodule update --init --recursive`
+
+1. add the following snippet at the end of both `sc-config/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml` and `wc-config/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml`
+
+    ```yaml
+    kubelet_config_extra_args:
+    imageGCHighThresholdPercent: 75
+    imageGCLowThresholdPercent: 70
+    ```
+
+1. Upgrade your cluster by running `./bin/ck8s-kubespray run-playbook sc upgrade-cluster.yml -b`.
+
+1. Upgrade your cluster by running `./bin/ck8s-kubespray run-playbook wc upgrade-cluster.yml -b`.

--- a/playbooks/ansible.cfg
+++ b/playbooks/ansible.cfg
@@ -1,0 +1,18 @@
+[ssh_connection]
+pipelining=True
+ssh_args = -o ControlMaster=auto -o ControlPersist=30m -o ConnectionAttempts=100 -o UserKnownHostsFile=/dev/null
+[defaults]
+# https://github.com/ansible/ansible/issues/56930 (to ignore group names with - and .)
+force_valid_group_names = ignore
+
+host_key_checking=True
+gathering = smart
+fact_caching = jsonfile
+fact_caching_connection = /tmp
+fact_caching_timeout = 7200
+stdout_callback = default
+display_skipped_hosts = no
+callback_whitelist = profile_tasks
+deprecation_warnings=False
+[inventory]
+ignore_patterns = artifacts, credentials

--- a/playbooks/prune_docker.yml
+++ b/playbooks/prune_docker.yml
@@ -1,0 +1,6 @@
+- hosts: all
+  tasks:
+    - name: Docker prune unused images, containers, networks etc.
+      command: docker system prune -a -f
+      register: command_output
+    - debug: msg="{{command_output.stdout_lines[-1:]}}"


### PR DESCRIPTION
**What this PR does / why we need it**:

When running ceph some nodes can become in a warning state as storage is low. I have seen that docker can have a lot of unused images, up to 20GB. So a easy step is to clear docker and this ansible will clear it up.

Also added ansible config file so that host key is not checked.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [x] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
