### PR TITLE
Qa 2.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Upgraded kubespray to 2.18.0
     Includes upgrade to Kubernetes v1.22.5.
+- Changed container manager to containerd
 
 -------------------------------------------------
 ## v2.17.1-ck8s1 - 2021-11-08

--- a/config/common/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml
+++ b/config/common/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml
@@ -22,6 +22,8 @@ kube_kubeadm_apiserver_extra_args:
 kube_proxy_mode: iptables
 kube_proxy_metrics_bind_address: "0.0.0.0:10249"
 
+container_manager: containerd
+
 enable_nodelocaldns: false
 
 kubernetes_audit: true

--- a/migration/v2.17.x-ck8s1-v2.18.x-ck8s1/upgrade-cluster.md
+++ b/migration/v2.17.x-ck8s1-v2.18.x-ck8s1/upgrade-cluster.md
@@ -1,0 +1,29 @@
+# Upgrade v2.16.0-ck8s1 to v2.17.x-ck8s1
+
+1. Checkout the new release: `git switch v2.18.0-ck8s1`
+
+1. Update the kubespray submodule: `git submodule update --init --recursive`
+
+1. Find `use_server_groups` in cluster.tfvars:
+    1. If set to `true`:
+        1. Add `master_server_group_policy` and `node_server_group_policy` and set both to `anti-affinity` otherwise the worker nodes will be recreated.
+    1. If set to `false` or missing:
+        1. Add `master_server_group_policy` and `node_server_group_policy` and set both to `""` otherwise they will be recreated.
+
+1. Run terraform plan `terraform plan -var-file cluster.tfvars ${CK8S_KUBESPRAY_REPO}/kubespray/contrib/terraform/<cloudprovider>`
+    For openstack clusters, there might be a `openstack_compute_servergroup_v2` with name `k8s-etcd-srvgrp` that gets deleted if you used server groups and didn't add the `etcd_server_group_policy`.
+    This is expected since we don't use separate etcd nodes.
+    If nodes are recreated, make sure to check previous step.
+
+1. Run terraform `terraform apply -var-file cluster.tfvars ${CK8S_KUBESPRAY_REPO}/kubespray/contrib/terraform/<cloudprovider>`
+
+1. Add `cinder_tolerations` to clusters that needs it.
+
+1. If you want to upgrade and start using containerd, follow [this guide](https://kubespray.io/#/docs/upgrades/migrate_docker2containerd) to migrate.
+    NOTE: If you are running Compliant Kubernetes. Make sure you're running a version that has support for conatinerd.
+
+    Else you can add `container_manager: docker` to end of both `sc-config/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml` and `wc-config/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml`
+
+1. Upgrade your service cluster by running `./bin/ck8s-kubespray run-playbook sc upgrade-cluster.yml -b`.
+
+1. Upgrade your workload cluster by running `./bin/ck8s-kubespray run-playbook wc upgrade-cluster.yml -b`.

--- a/migration/v2.17.x-ck8s1-v2.18.x-ck8s1/upgrade-cluster.md
+++ b/migration/v2.17.x-ck8s1-v2.18.x-ck8s1/upgrade-cluster.md
@@ -1,4 +1,6 @@
-# Upgrade v2.16.0-ck8s1 to v2.17.x-ck8s1
+# Upgrade v2.17.0-ck8s1 to v2.18.x-ck8s1
+
+**NOTE**: This release will upgrade Kubernetes to v1.22 which has removed a lot of APIs. See [this](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.22.md#whats-new-major-themes) for more information.
 
 1. Checkout the new release: `git switch v2.18.0-ck8s1`
 
@@ -26,4 +28,5 @@
 1. Upgrade your workload cluster by running `./bin/ck8s-kubespray run-playbook wc upgrade-cluster.yml -b`.
 
 1. After the upgrade, if you want to start using containerd follow [this guide](https://kubespray.io/#/docs/upgrades/migrate_docker2containerd) to migrate.
-    NOTE: If you are running Compliant Kubernetes. Make sure you're running a version that has support for conatinerd.
+
+**NOTE**: If you are running [Compliant Kubernetes Apps](https://github.com/elastisys/compliantkubernetes-apps). Make sure you're running a version that has support for conatinerd.

--- a/migration/v2.17.x-ck8s1-v2.18.x-ck8s1/upgrade-cluster.md
+++ b/migration/v2.17.x-ck8s1-v2.18.x-ck8s1/upgrade-cluster.md
@@ -19,11 +19,11 @@
 
 1. Add `cinder_tolerations` to clusters that needs it.
 
-1. If you want to upgrade and start using containerd, follow [this guide](https://kubespray.io/#/docs/upgrades/migrate_docker2containerd) to migrate.
-    NOTE: If you are running Compliant Kubernetes. Make sure you're running a version that has support for conatinerd.
-
-    Else you can add `container_manager: docker` to end of both `sc-config/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml` and `wc-config/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml`
+1. Add `container_manager: docker` to `${CK8S_CONFIG_PATH}/{wc,sc}-config/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml`
 
 1. Upgrade your service cluster by running `./bin/ck8s-kubespray run-playbook sc upgrade-cluster.yml -b`.
 
 1. Upgrade your workload cluster by running `./bin/ck8s-kubespray run-playbook wc upgrade-cluster.yml -b`.
+
+1. After the upgrade, if you want to start using containerd follow [this guide](https://kubespray.io/#/docs/upgrades/migrate_docker2containerd) to migrate.
+    NOTE: If you are running Compliant Kubernetes. Make sure you're running a version that has support for conatinerd.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds contained as default container manager. 
**Which issue this PR fixes** : fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [x] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
