### PR TITLE
Rook fixes

### DIFF
--- a/rook/deploy-rook.sh
+++ b/rook/deploy-rook.sh
@@ -13,7 +13,7 @@ chart_version="v1.5.3"
 
 # Install rook operator
 kubectl create namespace "${namespace}" --dry-run -o yaml | kubectl apply -f -
-kubectl label namespace "${namespace}" owner=operator
+kubectl label namespace "${namespace}" owner=operator --overwrite
 helm upgrade --install --namespace "${namespace}" "${release_name}" "${chart}" \
   --version "${chart_version}" --values "${here}/operator-values.yaml" --wait
 

--- a/rook/toolbox-deploy.yaml
+++ b/rook/toolbox-deploy.yaml
@@ -1,8 +1,13 @@
+# This file was originally downloaded from https://github.com/rook/rook/blob/c890710b635e2cd2ae64c08bac0621d89e79c0fc/deploy/examples/toolbox.yaml
+#
+# The following changes were performed:
+# - use stable container image, i.e., 'v1.8.6' instead of master
+# - add resource limits
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: rook-ceph-tools
-  namespace: rook-ceph # namespace:cluster
+  namespace: rook-ceph
   labels:
     app: rook-ceph-tools
 spec:
@@ -18,7 +23,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: rook-ceph-tools
-          image: rook/ceph:master
+          image: rook/ceph:v1.8.6
           command: ["/bin/bash"]
           args: ["-m", "-c", "/usr/local/bin/toolbox.sh"]
           imagePullPolicy: IfNotPresent
@@ -43,6 +48,10 @@ spec:
               name: ceph-config
             - name: mon-endpoint-volume
               mountPath: /etc/rook
+          resources:
+            requests:
+             cpu: "5m"
+             memory: "10Mi"
       volumes:
         - name: mon-endpoint-volume
           configMap:

--- a/rook/toolbox-deploy.yaml
+++ b/rook/toolbox-deploy.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: rook-ceph-tools
+  namespace: rook-ceph # namespace:cluster
   labels:
     app: rook-ceph-tools
 spec:
@@ -17,10 +18,15 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: rook-ceph-tools
-          image: rook/ceph:v1.5.3
-          command: ["/tini"]
-          args: ["-g", "--", "/usr/local/bin/toolbox.sh"]
+          image: rook/ceph:master
+          command: ["/bin/bash"]
+          args: ["-m", "-c", "/usr/local/bin/toolbox.sh"]
           imagePullPolicy: IfNotPresent
+          tty: true
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 2016
+            runAsGroup: 2016
           env:
             - name: ROOK_CEPH_USERNAME
               valueFrom:
@@ -37,10 +43,6 @@ spec:
               name: ceph-config
             - name: mon-endpoint-volume
               mountPath: /etc/rook
-          resources:
-            requests:
-             cpu: "5m"
-             memory: "10Mi"
       volumes:
         - name: mon-endpoint-volume
           configMap:


### PR DESCRIPTION
**What this PR does / why we need it**:

The rook-ceph-toolsbox image change and CrashLoops if created with the wrong Deployment. Pulling the latest version.

Also, the deploy script is not idempotent and may fail with:

```
error: 'owner' already has a value (operator), and --overwrite is false
```

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

N/A

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

N/A

**Special notes for reviewer**:


**Checklist:**

- [X] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [X] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
