### PR TITLE
docs: Added instructions to enable proxy protocol on citycloud

### DIFF
--- a/docs/citycloud-proxy-protocol-workaround.md
+++ b/docs/citycloud-proxy-protocol-workaround.md
@@ -1,0 +1,44 @@
+# Perserving source IP on CityCloud (proxy protocol)
+
+> NOTE: This workaround is not needed after [this PR](https://github.com/kubernetes-sigs/kubespray/pull/8629) is part of the release (probably at v1.23.0).
+
+To use proxy protocol on the loadbalancers on citycloud you'll need to update the cloud controller manager to version `v1.22.0`.
+This can be achieved by setting the following `k8s_cluster` group variables:
+
+```yaml
+external_openstack_cloud_controller_image_tag: "v1.22.0"
+external_openstack_enable_ingress_hostname: true
+```
+
+Apply the changes:
+
+```bash
+bin/ck8s-kubespray apply sc --tags=external-openstack
+```
+
+You also need to apply an updated clusterrole:
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/kubespray/be03d8ac2fca812c980c6515c8a6bb0d4b1ac243/roles/kubernetes-apps/external_cloud_controller/openstack/templates/external-openstack-cloud-controller-manager-roles.yml.j2
+```
+
+After this if you already have a loadbalancer you can add the annotation `loadbalancer.openstack.org/proxy-protocol: true` to the loadbalancer service and make sure that the backing service supports the proxy protocol.
+The cloud controller will automatically change the pool of the loadbalancer to use the proxy protocol so there might be a couple of seconds downtime while the change is made but otherwise it shouldn't change anything else.
+
+For [Compliant Kubernetes](https://github.com/elastisys/compliantkubernetes-apps) this specifically means making the following change:
+
+```diff
+ingressNginx:
+  controller:
+    config:
++     useProxyProtocol: true
+    service:
+      annotation:
++       loadbalancer.openstack.org/proxy-protocol: true
+```
+
+And then run:
+
+```bash
+bin/ck8s ops helmfile {sc|wc} -l app=ingress-nginx apply
+```


### PR DESCRIPTION
**What this PR does / why we need it**:

To get source IP preservation in citycloud clusters.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [x] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
