### PR TITLE
kubespray: switch to our fork for psp fix

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "kubespray"]
 	path = kubespray
-	url = https://github.com/kubernetes-sigs/kubespray
+	url = https://github.com/elastisys/kubespray

--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,8 +1,11 @@
 ### Changed
 
 - Changed default etcd version to 3.5.3
+- Switched to fork of kubespray. https://github.com/elastisys/kubespray
 
 ### Fixed
+
+- Fixed issue related to `kubeadm join` fail. Because there are no etcd pods mirrored by the kubelet, because of no psp were installed yet.
 
 ### Added
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Switch to elastisys fork of kubespray and update kubespray to v2.18.1 together with psp fix.

**Which issue this PR fixes**: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [x] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
