### PR TITLE
config: Updated default config to use etcd 3.5.3

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Changed
 
+- Changed default etcd version to 3.5.3
+
 ### Fixed
 
 ### Added

--- a/config/common/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml
+++ b/config/common/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml
@@ -4,6 +4,10 @@ kube_oidc_client_id: "kubelogin"
 kube_oidc_username_claim: "email"
 kube_oidc_groups_claim: "groups"
 
+etcd_version: v3.5.3
+etcd_binary_checksums:
+  amd64: e13e119ff9b28234561738cd261c2a031eb1c8688079dcf96d8035b3ad19ca58
+
 kube_apiserver_enable_admission_plugins:
   - "PodSecurityPolicy"
   - "NamespaceLifecycle"

--- a/migration/v2.17.x-ck8s1-v2.18.x-ck8s1/upgrade-cluster.md
+++ b/migration/v2.17.x-ck8s1-v2.18.x-ck8s1/upgrade-cluster.md
@@ -2,7 +2,7 @@
 
 **NOTE**: This release will upgrade Kubernetes to v1.22 which has removed a lot of APIs. See [this](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.22.md#whats-new-major-themes) for more information.
 
-1. Checkout the new release: `git switch v2.18.0-ck8s1`
+1. Checkout the new release: `git switch v2.18.1-ck8s1`
 
 1. Update the kubespray submodule: `git submodule update --init --recursive`
 
@@ -18,6 +18,14 @@
     If nodes are recreated, make sure to check previous step.
 
 1. Run terraform `terraform apply -var-file cluster.tfvars ${CK8S_KUBESPRAY_REPO}/kubespray/contrib/terraform/<cloudprovider>`
+
+1. Add the following to `${CK8S_CONFIG_PATH}/{wc,sc}-config/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml`
+
+    ```yaml
+    etcd_version: v3.5.3
+    etcd_binary_checksums:
+      amd64: e13e119ff9b28234561738cd261c2a031eb1c8688079dcf96d8035b3ad19ca58
+    ```
 
 1. Add `cinder_tolerations` to clusters that needs it.
 

--- a/migration/v2.18.0-ck8s1-v2.18.1-ck8s1/upgrade-cluster.md
+++ b/migration/v2.18.0-ck8s1-v2.18.1-ck8s1/upgrade-cluster.md
@@ -1,0 +1,17 @@
+# Upgrade v2.18.0-ck8s1 to v2.18.1-ck8s1
+
+1. Checkout the new release: `git switch v2.18.1-ck8s1`
+
+1. Update the kubespray submodule: `git submodule update --init --recursive`
+
+1. Add the following to `${CK8S_CONFIG_PATH}/{wc,sc}-config/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml`
+
+    ```yaml
+    etcd_version: v3.5.3
+    etcd_binary_checksums:
+      amd64: e13e119ff9b28234561738cd261c2a031eb1c8688079dcf96d8035b3ad19ca58
+    ```
+
+1. Upgrade your service cluster by running `./bin/ck8s-kubespray run-playbook sc upgrade-cluster.yml -b`.
+
+1. Upgrade your workload cluster by running `./bin/ck8s-kubespray run-playbook wc upgrade-cluster.yml -b`.


### PR DESCRIPTION
**What this PR does / why we need it**:

We want to upgrade to etcd 3.5.3 as soon as possible because of a data inconsistency issue.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #171

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [ ] is completely transparent, will not impact the workload in any way.
  - [x] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
