### PR TITLE
docs: Updated migration docs to sync remote

### DIFF
--- a/migration/v2.17.x-ck8s1-v2.18.x-ck8s1/upgrade-cluster.md
+++ b/migration/v2.17.x-ck8s1-v2.18.x-ck8s1/upgrade-cluster.md
@@ -6,6 +6,8 @@
 
 1. Update the kubespray submodule: `git submodule update --init --recursive`
 
+1. Update git remote for kubespray submodule: `git submodule sync`
+
 1. Find `use_server_groups` in cluster.tfvars:
     1. If set to `true`:
         1. Add `master_server_group_policy` and `node_server_group_policy` and set both to `anti-affinity` otherwise the worker nodes will be recreated.

--- a/migration/v2.18.0-ck8s1-v2.18.1-ck8s1/upgrade-cluster.md
+++ b/migration/v2.18.0-ck8s1-v2.18.1-ck8s1/upgrade-cluster.md
@@ -4,6 +4,8 @@
 
 1. Update the kubespray submodule: `git submodule update --init --recursive`
 
+1. Update git remote for kubespray submodule: `git submodule sync`
+
 1. Add the following to `${CK8S_CONFIG_PATH}/{wc,sc}-config/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml`
 
     ```yaml


### PR DESCRIPTION
**What this PR does / why we need it**:

To not confuse git command in kubespray folder.