### PR TITLE
added migration script to containerd

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,8 +20,8 @@ repos:
   - id: check-yaml
     args: [--allow-multiple-documents]
   - id: no-commit-to-branch
-- repo: https://github.com/jumanjihouse/pre-commit-hooks
-  rev: 2.1.4
+- repo: https://github.com/robonaut/pre-commit-hooks
+  rev: feature/ruby-3-compat
   hooks:
   - id: shellcheck
     additional_dependencies: []

--- a/migration/v2.17.x-ck8s1-v2.18.x-ck8s1/migrate-to-containerd.yml
+++ b/migration/v2.17.x-ck8s1-v2.18.x-ck8s1/migrate-to-containerd.yml
@@ -1,0 +1,122 @@
+- hosts: k8s_cluster
+  serial: 1
+  tasks:
+    - name: checking service status
+      service_facts:
+
+    - name: Migrate to containerd
+      block:
+        - name: Check that ansible version is >= 2.10.0
+          assert:
+            that:
+            - ansible_version.full is version('2.10.0', '>=')
+            fail_msg: "You need to have an ansible version >= 2.10.0"
+
+        - name: hostname
+          shell: echo $HOSTNAME
+          args:
+            executable: /bin/bash
+          register: hostname
+
+        - name: drain node
+          shell: kubectl drain {{hostname.stdout}} --ignore-daemonsets=true --delete-emptydir-data=true --force=true --kubeconfig /etc/kubernetes/admin.conf
+          delegate_to: "{{groups['kube_control_plane'][0]}}"
+
+        - name: Stop docker and kubelet services
+          systemd:
+            name: "{{ item }}"
+            state: stopped
+          with_items:
+            - 'docker'
+            - 'kubelet'
+
+        - name: remove docker and its dependencies
+          apt:
+            pkg:
+            - docker-ce
+            - docker-ce-cli
+            - docker-ce-rootless-extras
+            - containerd.io
+            state: absent
+            force: yes
+
+
+        - name: install pigz
+          apt:
+            name: pigz
+            state: present
+
+        - name: run kubespray on and limit to just one node.
+          become: no
+          command: ansible-playbook -i {{inventory_file}} ../../kubespray/cluster.yml --limit={{hostname.stdout}} -b
+          delegate_to: localhost
+
+        - name: annotate nodes with cri sock #The annotation is required by kubeadm to follow through future cluster upgrades.
+          command: kubectl annotate node {{hostname.stdout}} --overwrite kubeadm.alpha.kubernetes.io/cri-socket=/var/run/containerd/containerd.sock
+          delegate_to: "{{groups['kube_control_plane'][0]}}"
+
+        - name: Rebooting machine
+          shell: sleep 2 && shutdown -r now "Ansible updates triggered"
+          async: 1
+          poll: 0
+          ignore_errors: true
+
+        # Either ansible_host or ansible_ssh_host should be set to the target IP,
+        # but the other is probably set to localhost when running a local_action.
+        # So we need to pick the correct one.
+        # If both are set then a redundant wait is run.
+
+        - name: Waiting for the machine to come back (ansible_host)
+          local_action: wait_for host={{ ansible_host }} state=started port=22 delay=30 timeout=600
+          become: false
+          register: machine_up
+          when:
+          - ansible_host != "localhost"
+
+        - name: Waiting for the machine to come back (ansible_ssh_host)
+          local_action: wait_for host={{ ansible_ssh_host }} state=started port=22 delay=30 timeout=600
+          become: false
+          register: machine_up
+          when:
+          - ansible_ssh_host != "localhost"
+
+        - name: wait for kubectl access
+          command: kubectl get nodes --kubeconfig /etc/kubernetes/admin.conf
+          delegate_to: "{{groups['kube_control_plane'][0]}}"
+          register: kubectl_up
+          until: kubectl_up.rc == 0
+          retries: 30
+          delay: 3
+
+        - name: get time
+          debug:
+            var=ansible_date_time.iso8601
+          register: time
+
+        - name: Wait for node to start posting heartbeats
+          ansible.builtin.shell: $([[ {{time['ansible_date_time.iso8601']}} < $(kubectl get node {{hostname.stdout}} -o jsonpath='{.status.conditions[?(@.type=="Ready")].lastHeartbeatTime}' --kubeconfig /etc/kubernetes/admin.conf) ]])
+          delegate_to: "{{groups['kube_control_plane'][0]}}"
+          args:
+            executable: /bin/bash
+          register: kubelet_heartbeat
+          until: kubelet_heartbeat.rc == 0
+          retries: 60
+          delay: 3
+
+        - name: Wait for node to be ready
+          ansible.builtin.shell: $([[ $(kubectl get node {{hostname.stdout}} -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' --kubeconfig /etc/kubernetes/admin.conf) == "True" ]])
+          delegate_to: "{{groups['kube_control_plane'][0]}}"
+          args:
+            executable: /bin/bash
+          register: kubelet_ready
+          until: kubelet_ready.rc == 0
+          retries: 30
+          delay: 3
+
+        - name: uncordon node
+          command: kubectl uncordon {{hostname.stdout}} --kubeconfig /etc/kubernetes/admin.conf
+          delegate_to: "{{groups['kube_control_plane'][0]}}"
+      when:
+       - container_manager is defined
+       - container_manager == 'containerd'
+       - ansible_facts.services['containerd.service'] is not defined or (ansible_facts.services['containerd.service'] is defined and not ansible_facts.services['containerd.service'].state == 'running')

--- a/migration/v2.17.x-ck8s1-v2.18.x-ck8s1/upgrade-cluster.md
+++ b/migration/v2.17.x-ck8s1-v2.18.x-ck8s1/upgrade-cluster.md
@@ -45,6 +45,10 @@
 
 1. Upgrade your workload cluster by running `./bin/ck8s-kubespray run-playbook wc upgrade-cluster.yml -b`.
 
-1. After the upgrade, if you want to start using containerd follow [this guide](https://kubespray.io/#/docs/upgrades/migrate_docker2containerd) to migrate.
+1. After the upgrade, if you want to start using containerd follow [this guide](https://kubespray.io/#/docs/upgrades/migrate_docker2containerd) to migrate or set `container_manager: containerd` to `${CK8S_CONFIG_PATH}/{wc,sc}-config/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml` and run
+
+```bash
+./bin/ck8s-kubespray run-playbook {sc|wc} ../migration/v2.17.x-ck8s1-v2.18.x-ck8s1/migrate-to-containerd.yml -b
+```
 
 **NOTE**: If you are running [Compliant Kubernetes Apps](https://github.com/elastisys/compliantkubernetes-apps). Make sure you're running a version that has support for conatinerd.

--- a/migration/v2.18.0-ck8s1-v2.19.x-ck8s1/migrate-to-containerd.yml
+++ b/migration/v2.18.0-ck8s1-v2.19.x-ck8s1/migrate-to-containerd.yml
@@ -1,0 +1,122 @@
+- hosts: k8s_cluster
+  serial: 1
+  tasks:
+    - name: checking service status
+      service_facts:
+
+    - name: Migrate to containerd
+      block:
+        - name: Check that ansible version is >= 2.10.0
+          assert:
+            that:
+            - ansible_version.full is version('2.10.0', '>=')
+            fail_msg: "You need to have an ansible version >= 2.10.0"
+
+        - name: hostname
+          shell: echo $HOSTNAME
+          args:
+            executable: /bin/bash
+          register: hostname
+
+        - name: drain node
+          shell: kubectl drain {{hostname.stdout}} --ignore-daemonsets=true --delete-emptydir-data=true --force=true --kubeconfig /etc/kubernetes/admin.conf
+          delegate_to: "{{groups['kube_control_plane'][0]}}"
+
+        - name: Stop docker and kubelet services
+          systemd:
+            name: "{{ item }}"
+            state: stopped
+          with_items:
+            - 'docker'
+            - 'kubelet'
+
+        - name: remove docker and its dependencies
+          apt:
+            pkg:
+            - docker-ce
+            - docker-ce-cli
+            - docker-ce-rootless-extras
+            - containerd.io
+            state: absent
+            force: yes
+
+
+        - name: install pigz
+          apt:
+            name: pigz
+            state: present
+
+        - name: run kubespray on and limit to just one node.
+          become: no
+          command: ansible-playbook -i {{inventory_file}} ../../kubespray/cluster.yml --limit={{hostname.stdout}} -b
+          delegate_to: localhost
+
+        - name: annotate nodes with cri sock #The annotation is required by kubeadm to follow through future cluster upgrades.
+          command: kubectl annotate node {{hostname.stdout}} --overwrite kubeadm.alpha.kubernetes.io/cri-socket=/var/run/containerd/containerd.sock
+          delegate_to: "{{groups['kube_control_plane'][0]}}"
+
+        - name: Rebooting machine
+          shell: sleep 2 && shutdown -r now "Ansible updates triggered"
+          async: 1
+          poll: 0
+          ignore_errors: true
+
+        # Either ansible_host or ansible_ssh_host should be set to the target IP,
+        # but the other is probably set to localhost when running a local_action.
+        # So we need to pick the correct one.
+        # If both are set then a redundant wait is run.
+
+        - name: Waiting for the machine to come back (ansible_host)
+          local_action: wait_for host={{ ansible_host }} state=started port=22 delay=30 timeout=600
+          become: false
+          register: machine_up
+          when:
+          - ansible_host != "localhost"
+
+        - name: Waiting for the machine to come back (ansible_ssh_host)
+          local_action: wait_for host={{ ansible_ssh_host }} state=started port=22 delay=30 timeout=600
+          become: false
+          register: machine_up
+          when:
+          - ansible_ssh_host != "localhost"
+
+        - name: wait for kubectl access
+          command: kubectl get nodes --kubeconfig /etc/kubernetes/admin.conf
+          delegate_to: "{{groups['kube_control_plane'][0]}}"
+          register: kubectl_up
+          until: kubectl_up.rc == 0
+          retries: 30
+          delay: 3
+
+        - name: get time
+          debug:
+            var=ansible_date_time.iso8601
+          register: time
+
+        - name: Wait for node to start posting heartbeats
+          ansible.builtin.shell: $([[ {{time['ansible_date_time.iso8601']}} < $(kubectl get node {{hostname.stdout}} -o jsonpath='{.status.conditions[?(@.type=="Ready")].lastHeartbeatTime}' --kubeconfig /etc/kubernetes/admin.conf) ]])
+          delegate_to: "{{groups['kube_control_plane'][0]}}"
+          args:
+            executable: /bin/bash
+          register: kubelet_heartbeat
+          until: kubelet_heartbeat.rc == 0
+          retries: 60
+          delay: 3
+
+        - name: Wait for node to be ready
+          ansible.builtin.shell: $([[ $(kubectl get node {{hostname.stdout}} -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' --kubeconfig /etc/kubernetes/admin.conf) == "True" ]])
+          delegate_to: "{{groups['kube_control_plane'][0]}}"
+          args:
+            executable: /bin/bash
+          register: kubelet_ready
+          until: kubelet_ready.rc == 0
+          retries: 30
+          delay: 3
+
+        - name: uncordon node
+          command: kubectl uncordon {{hostname.stdout}} --kubeconfig /etc/kubernetes/admin.conf
+          delegate_to: "{{groups['kube_control_plane'][0]}}"
+      when:
+       - container_manager is defined
+       - container_manager == 'containerd'
+       - ansible_facts.services['containerd.service'] is not defined or (ansible_facts.services['containerd.service'] is defined and not ansible_facts.services['containerd.service'].state == 'running')

--- a/migration/v2.18.0-ck8s1-v2.19.x-ck8s1/upgrade-cluster.md
+++ b/migration/v2.18.0-ck8s1-v2.19.x-ck8s1/upgrade-cluster.md
@@ -15,3 +15,11 @@
 1. Upgrade your cluster by running `./bin/ck8s-kubespray run-playbook sc upgrade-cluster.yml -b`.
 
 1. Upgrade your cluster by running `./bin/ck8s-kubespray run-playbook wc upgrade-cluster.yml -b`.
+
+1. After the upgrade, if you want to start using containerd follow [this guide](https://kubespray.io/#/docs/upgrades/migrate_docker2containerd) to migrate or set `container_manager: containerd` to `${CK8S_CONFIG_PATH}/{wc,sc}-config/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml` and run
+
+```bash
+./bin/ck8s-kubespray run-playbook {sc|wc} ../migration/v2.18.0-ck8s1-v2.19.x-ck8s1/migrate-to-containerd.yml -b
+```
+
+**NOTE**: If you are running [Compliant Kubernetes Apps](https://github.com/elastisys/compliantkubernetes-apps). Make sure you're running a version that has support for conatinerd.


### PR DESCRIPTION
**What this PR does / why we need it**:
adds containerd migration script
**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [ ] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
