### PR TITLE
bin: add remove-node command

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,0 +1,2 @@
+### Added
+- Added `remove-node` command

--- a/bin/ck8s-kubespray
+++ b/bin/ck8s-kubespray
@@ -13,6 +13,8 @@ usage() {
     echo "      args: <prefix> <flavor> [<SOPS fingerprint>]" 1>&2
     echo "  apply                                       runs kubespray to create the cluster" 1>&2
     echo "      args: <prefix> [<options>]" 1>&2
+    echo "  remove-node                                 removes specified node from cluster" 1>&2
+    echo "      args: <prefix> <node_name> [<options>]" 1>&2
     echo "  run-playbook                                runs any ansible playbook in kubespray" 1>&2
     echo "      args: <prefix> <playbook> [<options>]" 1>&2
     echo "  apply-ssh                                   applies SSH keys from a file to a cluster" 1>&2
@@ -47,6 +49,13 @@ case "${1}" in
         fi
         shift 2
         "${here}/apply.bash" "${@}"
+        ;;
+    remove-node)
+        if [ $# -lt 2 ]; then
+            usage
+        fi
+        shift 2
+        "${here}/remove-node.bash" "${@}"
         ;;
     run-playbook)
         if [ $# -lt 3 ]; then

--- a/bin/remove-node.bash
+++ b/bin/remove-node.bash
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# This script will run the remove-node.yml playbook.
+# It will also install some python dependencies for kubespray in a virtual environment
+# It's not to be executed on its own but rather via `ck8s-kubespray remove-node <prefix> <node_name>` [<options>].
+
+set -eu -o pipefail
+shopt -s globstar nullglob dotglob
+
+if [ $# -lt 1 ]; then
+    echo "error when running $0: argument mismatch" 1>&2
+    exit 1
+fi
+
+playbook=remove-node.yml
+node_name=$1
+shift 1
+
+here="$(dirname "$(readlink -f "$0")")"
+# shellcheck source=bin/common.bash
+source "${here}/common.bash"
+
+check_openstack_credentials
+
+pushd "${kubespray_path}"
+
+if [ -z "${CK8S_KUBESPRAY_NO_VENV+x}" ]; then
+    log_info "Installing requirements for kubespray"
+    python3 -m venv venv
+    # shellcheck disable=SC1091
+    source venv/bin/activate
+    pip install -r requirements.txt
+fi
+
+log_info "Remvoing node: $node_name"
+
+# shellcheck disable=SC2145
+log_info Executing \"ansible-playbook -i "${config[inventory_file]}" "${playbook}" -b --extra-vars="node=${node_name}" "${@}"\"
+
+ansible-playbook -i "${config[inventory_file]}" "${playbook}" -b --extra-vars="node=${node_name}" "${@}"
+
+popd
+
+log_info "Kubespray done - playbook ${playbook} ran sucessfully!"


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes**:
fixes #175 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [x] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
