### PR TITLE
Reset changelog for release v2.19.0-ck8s1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "kubespray"]
 	path = kubespray
-	url = https://github.com/elastisys/kubespray
+	url = https://github.com/kubernetes-sigs/kubespray

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Compliant Kubernetes Kubespray changelog
 <!-- BEGIN TOC -->
+- [v2.19.0-ck8s1](#v2190-ck8s1---2022-06-14)
 - [v2.18.1-ck8s1](#v2181-ck8s1---2022-04-26)
 - [v2.18.0-ck8s1](#v2180-ck8s1---2022-02-08)
 - [v2.17.1-ck8s1](#v2171-ck8s1---2021-11-08)
@@ -7,6 +8,17 @@
 - [v2.16.0-ck8s1](#v2160-ck8s1---2021-07-02)
 - [v2.15.0-ck8s1](#v2150-ck8s1---2021-05-27)
 <!-- END TOC -->
+
+-------------------------------------------------
+## v2.19.0-ck8s1 - 2022-06-14
+
+### Changed
+
+- Use kubespray repository
+- Upgraded kubespray from v2.18.0 to v2.19.0.
+
+### Added
+- Added `remove-node` command
 
 -------------------------------------------------
 ## v2.18.1-ck8s1 - 2022-04-26

--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,7 +1,0 @@
-### Changed
-
-- Use kubespray repository
-- Upgraded kubespray from v2.18.0 to v2.19.0.
-
-### Added
-- Added `remove-node` command

--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,2 +1,7 @@
+### Changed
+
+- Use kubespray repository
+- Upgraded kubespray from v2.18.0 to v2.19.0.
+
 ### Added
 - Added `remove-node` command

--- a/migration/v2.18.0-ck8s1-v2.19.x-ck8s1/upgrade-cluster.md
+++ b/migration/v2.18.0-ck8s1-v2.19.x-ck8s1/upgrade-cluster.md
@@ -2,6 +2,8 @@
 
 1. Checkout the new release: `git checkout v2.19.x-ck8s1`
 
+1. Switch to the correct remote: `git submodule sync`
+
 1. Update the kubespray submodule: `git submodule update --init --recursive`
 
 1. add the following snippet at the end of both `sc-config/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml` and `wc-config/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml`


### PR DESCRIPTION
**What this PR does / why we need it**:

Reset changelog 

**Which issue this PR fixes**: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [x] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
