### PR TITLE
kubespray: upgrade to v2.19.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "kubespray"]
 	path = kubespray
-	url = https://github.com/elastisys/kubespray
+	url = https://github.com/kubernetes-sigs/kubespray

--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,2 +1,7 @@
+### Changed
+
+- Use kubespray repository
+- Upgraded kubespray from v2.18.0 to v2.19.0.
+
 ### Added
 - Added `remove-node` command

--- a/migration/v2.18.0-ck8s1-v2.19.x-ck8s1/upgrade-cluster.md
+++ b/migration/v2.18.0-ck8s1-v2.19.x-ck8s1/upgrade-cluster.md
@@ -2,6 +2,8 @@
 
 1. Checkout the new release: `git checkout v2.19.x-ck8s1`
 
+1. Switch to the correct remote: `git submodule sync`
+
 1. Update the kubespray submodule: `git submodule update --init --recursive`
 
 1. add the following snippet at the end of both `sc-config/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml` and `wc-config/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml`


### PR DESCRIPTION
**What this PR does / why we need it**:

Upgrade to new kubespray upgrade

**Which issue this PR fixes**: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [ ] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
