### PR TITLE
kubespray diff check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.1.0
+  rev: v4.3.0
   hooks:
   - id: end-of-file-fixer
   - id: trailing-whitespace
@@ -21,7 +21,7 @@ repos:
     args: [--allow-multiple-documents]
   - id: no-commit-to-branch
 - repo: https://github.com/robonaut/pre-commit-hooks
-  rev: feature/ruby-3-compat
+  rev: 2.1.6
   hooks:
   - id: shellcheck
     additional_dependencies: []

--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,0 +1,3 @@
+### Added
+
+- Added a check to see if the status of the kubespray git submodule differs from the expected status to hinder that people apply a different kubespray version than they want by mistake.

--- a/bin/apply.bash
+++ b/bin/apply.bash
@@ -10,7 +10,7 @@ shopt -s globstar nullglob dotglob
 here="$(dirname "$(readlink -f "$0")")"
 # shellcheck source=bin/common.bash
 source "${here}/common.bash"
-
+kubespray_version_check
 check_openstack_credentials
 
 log_info "Creating kubernetes cluster using kubespray"

--- a/bin/common.bash
+++ b/bin/common.bash
@@ -228,3 +228,29 @@ check_openstack_credentials() {
         exit 1
     fi
 }
+
+# Compares the expected and actual git state of the kubespray submodule.
+# If they don't match the user will be asked if they want to continue anyway.
+kubespray_version_check(){
+   pushd "${here}/../" || exit
+
+   git_diff=$(git diff kubespray/)
+
+   popd || exit
+
+   if [[ $git_diff ]]; then
+
+        expected_commit=$(echo "${git_diff}" | grep -m1 commit | grep -o '[^ ]*$')
+        current_commit=$(echo "${git_diff}" | tail -n 1 | grep -o '[^ ]*$')
+
+        log_info "The status of the kubespray git submodule differs from the expected status, either it is on another commit or there are file changes. This can cause unexpected versions to be installed or cause other errors. We recommend that you stop and check what has changed."
+        log_info "Expected" "${expected_commit}", "got" "${current_commit}".
+        log_info_no_newline "Do you want to abort? (Y/n): "
+
+        read -r reply
+
+        if [[ "${reply}" != "n" ]]; then
+            exit 1
+        fi
+   fi
+}

--- a/bin/run-playbook.bash
+++ b/bin/run-playbook.bash
@@ -18,7 +18,7 @@ shift 1
 here="$(dirname "$(readlink -f "$0")")"
 # shellcheck source=bin/common.bash
 source "${here}/common.bash"
-
+kubespray_version_check
 check_openstack_credentials
 
 log_info "Running kubespray playbook ${playbook}"


### PR DESCRIPTION
**What this PR does / why we need it**:
If you miss to do a submodule update after checking out a version of ck8s-kubespray then you might install the wrong version of kubernetes or get other errors. This is now fixed by adding a dialog for if the kubespray git submodule differs from the expected status.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #163

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [x] Proper commit message prefix on all commits
- [x] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [x] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
