### PR TITLE
bin: updated common.bash yq commands to work with yq v4.18+

### DIFF
--- a/bin/common.bash
+++ b/bin/common.bash
@@ -64,13 +64,13 @@ validate_sops_config() {
         exit 1
     fi
 
-    rule_count=$(yq r - --length creation_rules < "${sops_config}")
+    rule_count=$(yq 'length' < "${sops_config}")
     if [ "${rule_count:-0}" -gt 1 ]; then
         log_error "ERROR: SOPS config has more than one creation rule."
         exit 1
     fi
 
-    fingerprints=$(yq r - 'creation_rules[0].pgp' < "${sops_config}")
+    fingerprints=$(yq '."creation_rules[0].pgp"' < "${sops_config}")
     if ! [[ "${fingerprints}" =~ ^[A-Z0-9,' ']+$ ]]; then
         log_error "ERROR: SOPS config contains no or invalid PGP keys."
         log_error "fingerprints=${fingerprints}"
@@ -106,7 +106,7 @@ append_trap() {
 
 # Write PGP fingerprints to SOPS config
 sops_config_write_fingerprints() {
-    yq n 'creation_rules[0].pgp' "${1}" > "${sops_config}" || \
+    yq e -n '{"creation_rules[0].pgp" : "'${1}'"}' > "${sops_config}" || \
       (log_error "Failed to write fingerprints" && rm "${sops_config}" && exit 1)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes the sops config generation and validations command to work with yq v4.18+
**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [ ] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
