### PR TITLE
bin: add openstack terraform migration script for 2.18 -> 2.19

### DIFF
--- a/migration/v2.19.0-ck8s1-v2.19.0-ck8s2/migrate-terraform-openstack.sh
+++ b/migration/v2.19.0-ck8s1-v2.19.0-ck8s2/migrate-terraform-openstack.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# shellcheck disable=SC2002
+
+: "${CK8S_CONFIG_PATH:?Missing CK8S_CONFIG_PATH}"
+: "${OS_USERNAME:?Missing OS_USERNAME}"
+: "${OS_PASSWORD:?Missing OS_PASSWORD}"
+
+here="$(dirname "$(readlink -f "$0")")"
+openstack_terraform_dir="${here}/../../kubespray/contrib/terraform/openstack"
+
+# shellcheck disable=SC1090
+source "${CK8S_CONFIG_PATH}/openrc.sh"
+
+# Rendered cloudinit template file with nothing in it, will always be the same for already set up clusters
+USER_DATA=a59f82a5a0ceedbc94016fb22248ba033dfcb315
+
+for CLUSTER in sc wc; do
+  pushd "${CK8S_CONFIG_PATH}/${CLUSTER}-config" || return
+  terraform init "${openstack_terraform_dir}"
+  node_ids=( "$(cat terraform.tfstate | jq -r '.resources[] | select(.type == "openstack_compute_instance_v2").instances[].attributes.id')" )
+  cp terraform.tfstate terraform-temp.tfstate
+  echo "Getting openstack ports"
+  openstack port list -f json > ports.json
+
+  # shellcheck disable=SC2068
+  for node in ${node_ids[@]}; do
+      mac_address=$(cat terraform.tfstate | jq -r '.resources[] | select(.type == "openstack_compute_instance_v2").instances[] | select(.attributes.id == "'"${node}"'").attributes.network[].mac')
+      port_id=$(cat ports.json | jq -r '.[] | select(."MAC Address" == "'"${mac_address}"'").ID')
+      node_type_name=$(cat terraform.tfstate | jq -r '.resources[] | select(.type == "openstack_compute_instance_v2" and .instances[].attributes.id == "'"${node}"'").name')
+      index_key=$(cat terraform.tfstate | jq -r '.resources[] | select(.type == "openstack_compute_instance_v2").instances[] | select(.attributes.id == "'"${node}"'").index_key')
+      # Check if index key is a number or not, to determine how the imported ports should be indexed
+      # Then, terraform import the openstack ports
+      re='^[0-9]+$'
+      if [[ "${index_key}" =~ $re ]]; then
+        terraform import -state=terraform-temp.tfstate -config="${openstack_terraform_dir}" -var-file=cluster.tfvars module.compute.openstack_networking_port_v2."${node_type_name}"_port["${index_key}"] "${port_id}"
+      else
+        terraform import -state=terraform-temp.tfstate -config="${openstack_terraform_dir}" -var-file=cluster.tfvars module.compute.openstack_networking_port_v2."${node_type_name}"_port[\""${index_key}"\"] "${port_id}"
+      fi
+      # Add port ID to node resource
+      cat terraform-temp.tfstate | jq -r '(.resources[] | select(.type == "openstack_compute_instance_v2").instances[] | select(.attributes.id == "'"${node}"'").attributes.network[].port) = "'"${port_id}"'"' > terraform-temp2.tfstate
+      mv terraform-temp2.tfstate terraform-temp.tfstate
+  done
+
+  # Add user_data field to nodes
+  cat terraform-temp.tfstate | jq -r '(.resources[] | select(.type == "openstack_compute_instance_v2" and .name != "k8s_master_no_floating_ip").instances[].attributes.user_data) = "'"${USER_DATA}"'"' > terraform-temp2.tfstate
+  mv terraform-temp2.tfstate terraform-temp.tfstate
+  rm ports.json
+  popd || return
+done
+
+echo "New terraform state can be found in ${CK8S_CONFIG_PATH}/<sc|wc>-config/terraform-temp.tfstate"
+echo "Try running terraform plan with this state to see that no nodes get destroyed, then mv terraform-temp.tfstate terraform.tfstate"
+echo "Then, run terraform apply to finish making the changes"

--- a/migration/v2.19.0-ck8s1-v2.19.0-ck8s2/upgrade-cluster.md
+++ b/migration/v2.19.0-ck8s1-v2.19.0-ck8s2/upgrade-cluster.md
@@ -56,3 +56,7 @@
     kubeconfig_file_name: <kube_config_sc.yaml|kube_config_wc.yaml>
     artifacts_dir: "{{ inventory_dir }}/../.state"
     ```
+
+## Update terraform state for Openstack environments
+
+1. If you're running on an openstack cloud provider, you will have to update the terraform state. This can be done by exporting `CK8S_CONFIG_PATH`, `OS_USERNAME` and `OS_PASSWORD`, and then running `migrate-terraform-openstack.sh` and following the instructions that are shown after the script finishes.


### PR DESCRIPTION
**What this PR does / why we need it**: Added migration script for the terraform state for v2.18 -> v2.19 for openstack environments to prevent terraform from trying to recreate nodes.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #176

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

The issue states that the script should make it so that terraform doesn't want to change anything, but I think because of how significantly the terraform module has changed this is not really viable. The script will make it so that terraform doesn't try to destroy anything important, but it will make some changes to the state.

I have tried this on safespring and citycloud. You can test the script yourself on any environment, since it only makes local changes.

**Checklist:**

- [X] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [ ] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
