### PR TITLE
docs: update migration guide for v2.19.0-ck8s2

### DIFF
--- a/migration/v2.19.0-ck8s1-v2.19.0-ck8s2/upgrade-cluster.md
+++ b/migration/v2.19.0-ck8s1-v2.19.0-ck8s2/upgrade-cluster.md
@@ -59,4 +59,18 @@
 
 ## Update terraform state for Openstack environments
 
-1. If you're running on an openstack cloud provider, you will have to update the terraform state. This can be done by exporting `CK8S_CONFIG_PATH`, `OS_USERNAME` and `OS_PASSWORD`, and then running `migrate-terraform-openstack.sh` and following the instructions that are shown after the script finishes.
+If you're running on an Openstack cloud provider, you will have to update the terraform state. *This only applies to Openstack environments that have been upgraded from kubespray v2.18. For environments that were initially set up on v2.19, you do not need to perform the steps below.*
+
+1. For Safespring environments only, add the following to your `sc-config/cluster.tfvars` and `wc-config/cluster.tfvars`:
+
+    ```yaml
+    use_existing_network = true
+    port_security_enabled = true
+    force_null_port_security = true
+    ```
+
+1. Export `CK8S_CONFIG_PATH`, `OS_USERNAME` and `OS_PASSWORD`, and then run `migrate-terraform-openstack.sh`. The script will create a new terraform state called `terraform-temp.tfstate` in both the `sc-config` and `wc-config` folders.
+
+1. Run `terraform plan` with `-state terraform-temp.tfstate` on both clusters and confirm that terraform does not try to destroy any infrastructure.
+
+1. After confirming, run `mv terraform-temp.tfstate terraform.tfstate` in both the `sc-config` and `wc-config` folders, and then run `terraform apply` with the new state to finish making the changes. There may be temporary network interruptions while performing this step.


### PR DESCRIPTION
**What this PR does / why we need it**: Updated the migration guide steps for the openstack terraform state with some config that is necessary for Safespring environments, and made the rest of the steps a bit more clear.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [X] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [ ] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
