### PR TITLE
Release 2.19.0 fixes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "kubespray"]
 	path = kubespray
-	url = https://github.com/kubernetes-sigs/kubespray
+	url = https://github.com/elastisys/kubespray

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@
 
 ### Changed
 
-- Use kubespray repository
 - Upgraded kubespray from v2.18.0 to v2.19.0.
 
 ### Added

--- a/config/common/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml
+++ b/config/common/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml
@@ -17,10 +17,6 @@ cluster_admin_groups:
 - admin-group
 kubeconfig_localhost: false
 
-etcd_version: v3.5.3
-etcd_binary_checksums:
-  amd64: e13e119ff9b28234561738cd261c2a031eb1c8688079dcf96d8035b3ad19ca58
-
 kube_apiserver_enable_admission_plugins:
   - "PodSecurityPolicy"
   - "NamespaceLifecycle"
@@ -116,3 +112,7 @@ calico_felix_prometheusmetricsenabled: true
 kubelet_config_extra_args:
   imageGCHighThresholdPercent: 75
   imageGCLowThresholdPercent: 70
+
+calico_ipip_mode: 'Always'
+calico_vxlan_mode: 'Never'
+calico_network_backend: 'bird'

--- a/config/openstack/group_vars/k8s_cluster/ck8s-k8s-cluster-openstack.yaml
+++ b/config/openstack/group_vars/k8s_cluster/ck8s-k8s-cluster-openstack.yaml
@@ -1,4 +1,4 @@
-etcd_kubeadm_enabled: true
+etcd_deployment_type: kubeadm
 
 cloud_provider: external
 external_cloud_provider: openstack
@@ -40,3 +40,5 @@ storage_classes:
 #   - "ext-net"
 # external_openstack_metadata_search_order: "configDrive,metadataService"
 # supplementary_addresses_in_ssl_keys: []
+
+# kubeconfig_localhost_ansible_host: true

--- a/migration/v2.18.0-ck8s1-v2.19.x-ck8s1/clear-old-ansible-versions.sh
+++ b/migration/v2.18.0-ck8s1-v2.19.x-ck8s1/clear-old-ansible-versions.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+here="$(dirname "$(readlink -f "$0")")"
+
+pushd "${here}/../../kubespray" || return
+
+python3 -m venv venv
+# shellcheck source=/dev/null
+source venv/bin/activate
+
+pip uninstall ansible -y
+pip uninstall ansible-base -y
+pip uninstall ansible-core -y
+pip uninstall wheel -y
+
+deactivate
+popd || return

--- a/migration/v2.18.0-ck8s1-v2.19.x-ck8s1/upgrade-cluster.md
+++ b/migration/v2.18.0-ck8s1-v2.19.x-ck8s1/upgrade-cluster.md
@@ -2,6 +2,8 @@
 
 1. Checkout the new release: `git checkout v2.19.x-ck8s1`
 
+> The new kubespray version does not work with older terraform setups. If terraform actions are needed revert to v2.18.1 or migrate the terraform state once this [issue](https://github.com/elastisys/compliantkubernetes-kubespray/issues/176) is closed.
+
 1. Switch to the correct remote: `git submodule sync`
 
 1. Update the kubespray submodule: `git submodule update --init --recursive`
@@ -13,6 +15,49 @@
     imageGCHighThresholdPercent: 75
     imageGCLowThresholdPercent: 70
     ```
+
+1. remove any snippet specifying etc version in  `sc-config/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml` and `wc-config/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml` or in any other place
+
+    ```diff
+    -etcd_version: v3.5.3
+    -etcd_binary_checksums:
+    -amd64: e13e119ff9b28234561738cd261c2a031eb1c8688079dcf96d8035b3ad19ca58
+    ```
+
+1. add the following snippet at the end of both `sc-config/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml` and `wc-config/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml`
+
+    ```yaml
+    calico_ipip_mode: 'Always'
+    calico_vxlan_mode: 'Never'
+    calico_network_backend: 'bird'
+    ```
+
+    If vxlan is preferred over ipip, please refer to this [document](https://github.com/kubernetes-sigs/kubespray/blob/v2.19.0/docs/calico.md#config-encapsulation-for-cross-server-traffic)
+
+1. replace the following snippet in both `sc-config/group_vars/k8s_cluster/ck8s-k8s-cluster-openstack.yaml` and `wc-config/group_vars/k8s_cluster/ck8s-k8s-cluster-openstack.yaml`
+
+    ```diff
+    -etcd_kubeadm_enabled: true
+    +etcd_deployment_type: kubeadm
+    ```
+
+1. Clear the old ansible versions before running the upgrade
+
+    ```console
+    ./migration/v2.18.0-ck8s1-v2.19.x-ck8s1/clear-old-ansible-versions.sh
+    ```
+
+1. Upgrade time, the sc cluster takes about 90 minutes.
+
+    During the upgrade keep an eye on the nodes. Nodes that are in `notReady` and have the events
+
+    ```console
+    kubectl describe nodes <node>
+    ....
+    Warning  InvalidDiskCapacity      7s     kubelet     invalid capacity 0 on image filesystem
+    ```
+
+    needs a reboot. It is a bug that is fixed in [v1.24.0](https://github.com/kubernetes/kubernetes/pull/108325)
 
 1. Upgrade your cluster by running `./bin/ck8s-kubespray run-playbook sc upgrade-cluster.yml -b`.
 

--- a/migration/v2.18.0-ck8s1-v2.19.x-ck8s1/upgrade-cluster.md
+++ b/migration/v2.18.0-ck8s1-v2.19.x-ck8s1/upgrade-cluster.md
@@ -70,3 +70,5 @@
 ```
 
 **NOTE**: If you are running [Compliant Kubernetes Apps](https://github.com/elastisys/compliantkubernetes-apps). Make sure you're running a version that has support for conatinerd.
+
+**NOTE**: Don't forget to do migration steps in [../v2.19.0-ck8s1-v2.19.0-ck8s2](https://github.com/elastisys/compliantkubernetes-kubespray/tree/main/migration/v2.19.0-ck8s1-v2.19.0-ck8s2) folder if you are upgrading from `v2.18.0-ck8s1` to `v2.19.0-ck8s2`.


### PR DESCRIPTION
**What this PR does / why we need it**:

fixes from 2.19.0 release branch

**Special notes for reviewer**:

**Checklist:**

- [X] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [ ] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
