### PR TITLE
Doc: fix migration doc

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
     args: [--allow-multiple-documents]
   - id: no-commit-to-branch
 - repo: https://github.com/robonaut/pre-commit-hooks
-  rev: 2.1.6
+  rev: 2.2.0-rc.1
   hooks:
   - id: shellcheck
     additional_dependencies: []

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Compliant Kubernetes Kubespray changelog
 <!-- BEGIN TOC -->
+- [v2.19.0-ck8s2](#v2190-ck8s2---2022-07-22)
 - [v2.19.0-ck8s1](#v2190-ck8s1---2022-06-14)
 - [v2.18.1-ck8s1](#v2181-ck8s1---2022-04-26)
 - [v2.18.0-ck8s1](#v2180-ck8s1---2022-02-08)
@@ -8,6 +9,19 @@
 - [v2.16.0-ck8s1](#v2160-ck8s1---2021-07-02)
 - [v2.15.0-ck8s1](#v2150-ck8s1---2021-05-27)
 <!-- END TOC -->
+
+-------------------------------------------------
+## v2.19.0-ck8s2 - 2022-07-22
+
+### Added
+
+- Added a check to see if the status of the kubespray git submodule differs from the expected status to hinder that people apply a different kubespray version than they want by mistake.
+- New playbook `playbooks/kubeconfig.yml` to manage kubeconfigs. It can either move the cluster admin kubeconfig that kubespray produces or create an OIDC kubeconfig. This comes with several new group vars.
+- New playbook `playbooks/cluster_admin_rbac.yml` to add cluster admin RBAC for OIDC users. This comes with several new group vars.
+
+### Changed
+
+- Apply command uses the new ansible playbooks to manage kubeconfigs and OIDC clusteradmin RBAC.
 
 -------------------------------------------------
 ## v2.19.0-ck8s1 - 2022-06-14

--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,0 +1,3 @@
+### Changed
+
+- pre-commit rev update to `2.2.0-rc.1`

--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,9 +1,0 @@
-### Added
-
-- Added a check to see if the status of the kubespray git submodule differs from the expected status to hinder that people apply a different kubespray version than they want by mistake.
-- New playbook `playbooks/kubeconfig.yml` to manage kubeconfigs. It can either move the cluster admin kubeconfig that kubespray produces or create an OIDC kubeconfig. This comes with several new group vars.
-- New playbook `playbooks/cluster_admin_rbac.yml` to add cluster admin RBAC for OIDC users. This comes with several new group vars.
-
-### Changed
-
-- Apply command uses the new ansible playbooks to manage kubeconfigs and OIDC clusteradmin RBAC.

--- a/migration/v2.18.0-ck8s1-v2.19.x-ck8s1/upgrade-cluster.md
+++ b/migration/v2.18.0-ck8s1-v2.19.x-ck8s1/upgrade-cluster.md
@@ -12,8 +12,8 @@
 
     ```yaml
     kubelet_config_extra_args:
-    imageGCHighThresholdPercent: 75
-    imageGCLowThresholdPercent: 70
+        imageGCHighThresholdPercent: 75
+        imageGCLowThresholdPercent: 70
     ```
 
 1. remove any snippet specifying etc version in  `sc-config/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml` and `wc-config/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml` or in any other place

--- a/migration/v2.19.0-ck8s1-v2.19.0-ck8s2/upgrade-cluster.md
+++ b/migration/v2.19.0-ck8s1-v2.19.0-ck8s2/upgrade-cluster.md
@@ -35,18 +35,25 @@
 1. For service clusters that is using dex as OIDC client it is recommended to switch to your IDP, for example Google. This allows the sc kubeconfig to work even if dex is down. To do that, change the following variables in `sc-config/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml` to use the values from your IDP. For Google you cannot use the same OIDC client here as in dex, you must create an OAuth client of type `Desktop app`.
 
     ```yaml
-    kube_oidc_url: <IDP-URL> #e.g. https://accounts.google.com/
+    kube_oidc_url: <IDP-URL> #e.g. https://accounts.google.com
     kube_oidc_client_id: <id-from-IDP>
     kube_oidc_client_secret: <secret-from-IDP>
     ```
 
-    Then update the apiserver by running: `./bin/ck8s-kubespray run-playbook sc upgrade-cluster.yml -b --limit "kube_control_plane" --tags "download,master"`
-
 1. If you are connecting directly to Google as an IDP, then you must remove `kube_oidc_groups_claim: "groups"`, since they do not support group claims via OIDC.
+
+1. Then update the apiserver by running: `./bin/ck8s-kubespray run-playbook sc upgrade-cluster.yml -b --limit "kube_control_plane" --tags "download,master"`
 
 1. Create the new OIDC kubeconfigs by running: `./bin/ck8s-kubespray run-playbook sc ../playbooks/kubeconfig.yml -b` and `./bin/ck8s-kubespray run-playbook wc ../playbooks/kubeconfig.yml -b`. NOTE: this will overwrite any existing file at `kubeconfig_file_name` in `artifacts_dir`.
 
 1. Create the new OIDC cluster admin RBAC by running: `./bin/ck8s-kubespray run-playbook sc ../playbooks/cluster_admin_rbac.yml -b` and `./bin/ck8s-kubespray run-playbook wc ../playbooks/cluster_admin_rbac.yml -b`
+
+1. If you are running compliantkubernetes-apps version <= v0.22 you need to encrypt the newly created kubeconfigs.
+
+    ```console
+    sops -e -i $CK8S_CONFIG_PATH/.state/kube_config_sc.yaml
+    sops -e -i $CK8S_CONFIG_PATH/.state/kube_config_wc.yaml
+    ```
 
 ## Keep using regular kubeconfigs
 
@@ -74,3 +81,10 @@ If you're running on an Openstack cloud provider, you will have to update the te
 1. Run `terraform plan` with `-state terraform-temp.tfstate` on both clusters and confirm that terraform does not try to destroy any infrastructure.
 
 1. After confirming, run `mv terraform-temp.tfstate terraform.tfstate` in both the `sc-config` and `wc-config` folders, and then run `terraform apply` with the new state to finish making the changes. There may be temporary network interruptions while performing this step.
+
+1. Lastly copy over the new dynamic inventory script
+
+    ```console
+    cp ${CK8S_KUBESPRAY_REPO}/kubespray/contrib/terraform/terraform.py ${CK8S_CONFIG_PATH}/sc-config/inventory.ini
+    cp ${CK8S_KUBESPRAY_REPO}/kubespray/contrib/terraform/terraform.py ${CK8S_CONFIG_PATH}/wc-config/inventory.ini
+    ```


### PR DESCRIPTION
**What this PR does / why we need it**:

Added commit for reset of WIP
Fix small issues in migration doc for v2.18 -> v2.19

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [x] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
