### PR TITLE
Clarify API stability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # Elastisys Compliant Kubernetes Kubespray
 
-**NOTE: This project is in alpha stage and is actively developed. Therefore the API may change in backwards-incompatible ways.**
+## On API Stability
 
-Content:
+⚠️  Please note that the Elastisys Compliant Kubernetes Kubespray project frequently changes admin-facing API, i.e., configuration, in a backwards-incompatible way. Make sure to read the [change log](CHANGELOG.md) and the [migration steps](/migration). These migration steps are subject to quality assurance and are used in production environments. Hence, if properly executed, they shouldn't cause any downtime.
+
+The user-facing API changes more rarely, usually as a result of a Kubernetes version upgrade. For details, read the [user-facing release notes](https://elastisys.io/compliantkubernetes/release-notes/#compliant-kubernetes-kubespray).
+
+## Content
 
 - `bin`: wrapper scripts that helps you run kubespray
 - `config`: default config values


### PR DESCRIPTION
**What this PR does / why we need it**:

The current wording -- in particular the word "alpha" -- makes the project sound immature. This is in contrast to the fact that the project successfully serves a double-digit production environments with high up-time. Hence, let's fix the wording to give the project the praise it deserves. :smile:

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [X] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [X] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
