### PR TITLE
bin: Updated to yq4

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,3 +1,8 @@
+### Release notes
+- Scripts are now using yq version 4
+  - Requires `yq4` as an alias to yq v4.
+
 ### Changed
 
 - pre-commit rev update to `2.2.0-rc.1`
+- Scripts are now using yq version 4

--- a/bin/common.bash
+++ b/bin/common.bash
@@ -59,13 +59,13 @@ validate_sops_config() {
         exit 1
     fi
 
-    rule_count=$(yq r - --length creation_rules < "${sops_config}")
+    rule_count=$(yq4 '.creation_rules | length' "${sops_config}")
     if [ "${rule_count:-0}" -gt 1 ]; then
         log_error "ERROR: SOPS config has more than one creation rule."
         exit 1
     fi
 
-    fingerprints=$(yq r - 'creation_rules[0].pgp' < "${sops_config}")
+    fingerprints=$(yq4 '.creation_rules[0].pgp' "${sops_config}")
     if ! [[ "${fingerprints}" =~ ^[A-Z0-9,' ']+$ ]]; then
         log_error "ERROR: SOPS config contains no or invalid PGP keys."
         log_error "fingerprints=${fingerprints}"
@@ -101,7 +101,7 @@ append_trap() {
 
 # Write PGP fingerprints to SOPS config
 sops_config_write_fingerprints() {
-    yq n 'creation_rules[0].pgp' "${1}" > "${sops_config}" || \
+    yq4 -n '.creation_rules[0].pgp = "'"${1}"'"' > "${sops_config}" || \
       (log_error "Failed to write fingerprints" && rm "${sops_config}" && exit 1)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Changed to use yq version 4

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #202

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [ ] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
