### PR TITLE
config: fix for cis kube-bench test fail

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -6,3 +6,6 @@
 
 - pre-commit rev update to `2.2.0-rc.1`
 - Scripts are now using yq version 4
+
+## Fixed
+- Fixed multiple kube-bench fails (01.03.07, 01.04.01, 01.04.02)

--- a/config/common/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml
+++ b/config/common/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml
@@ -116,3 +116,11 @@ kubelet_config_extra_args:
 calico_ipip_mode: 'Always'
 calico_vxlan_mode: 'Never'
 calico_network_backend: 'bird'
+
+kube_profiling: false
+
+kube_scheduler_bind_address: 127.0.0.1
+kube_kubeadm_scheduler_extra_args:
+    profiling: false
+
+kube_controller_manager_bind_address: 127.0.0.1

--- a/migration/v2.19.0-ck8s2-v2.20.x-ck8s1/upgrade-cluster.md
+++ b/migration/v2.19.0-ck8s2-v2.20.x-ck8s1/upgrade-cluster.md
@@ -1,0 +1,23 @@
+# Upgrade v2.19.0-ck8s2 to v2.20.x-ck8s1
+
+1. Checkout the new release: `git checkout v2.20.x-ck8s1`
+
+1. Switch to the correct remote: `git submodule sync`
+
+1. Update the kubespray submodule: `git submodule update --init --recursive`
+
+1. Add the following snippet at the end of both `sc-config/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml` and `wc-config/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml`
+
+    ```diff
+    +kube_profiling: false
+
+    +kube_scheduler_bind_address: 127.0.0.1
+    +kube_kubeadm_scheduler_extra_args:
+    +    profiling: false
+
+    +kube_controller_manager_bind_address: 127.0.0.1
+    ```
+
+1. Upgrade your service cluster by running `./bin/ck8s-kubespray run-playbook sc upgrade-cluster.yml -b`.
+
+1. Upgrade your workload cluster by running `./bin/ck8s-kubespray run-playbook wc upgrade-cluster.yml -b`.


### PR DESCRIPTION
**What this PR does / why we need it**:

Added fixes for cis kube-bench tests that fail for the master nodes.

I just found that kubespray have this [document](https://github.com/kubernetes-sigs/kubespray/blob/master/docs/hardening.md) about hardening. Could be worth going through it. 

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [x] Proper commit message prefix on all commits
- [x] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [x] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
