### PR TITLE
docs: fix links to public docs

### DIFF
--- a/release/README.md
+++ b/release/README.md
@@ -93,7 +93,7 @@ The releases will have the following version string: `<kubespray-version>-<ck8s-
 
 1. Update public release notes.
 
-    When a released is published the public [user-facing release notes](https://github.com/elastisys/compliantkubernetes/blob/main/docs/compliantkubernetes/release-notes/kubespray.md) needs to be updated. The new release needs to be added and the list can be trimmed down to only include the supported versions.
+    When a release is published the public [user-facing release notes](https://github.com/elastisys/compliantkubernetes/blob/main/docs/release-notes/kubespray.md) needs to be updated. The new release needs to be added and the list can be trimmed down to only include the supported versions.
 
     Add bullet points of major changes within the cluster that affects the user as defined [here](https://compliantkubernetes.io/user-guide/). This includes any change within the cluster that may impact the user experience, for example new or updated feature, or the deprecation of features.
 


### PR DESCRIPTION
**What this PR does / why we need it**:

fix link

**Checklist:**

- [X] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [X] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
