### PR TITLE
ck8s:Fix cluster.local in kubeconfigs

### DIFF
--- a/config/common/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml
+++ b/config/common/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml
@@ -3,6 +3,7 @@ kube_oidc_url: <IDP-URL|https://dex.BASE-DOMAIN>
 kube_oidc_client_id: <id-from-IDP|kubelogin>
 kube_oidc_client_secret: <secret-from-IDP|secret-from-dex>
 kube_oidc_username_claim: "email"
+kubeconfig_cluster_name: <CHANGE-ME-ENVIRONMENT-NAME-sc|CHANGE-ME-ENVIRONMENT-NAME-wc>
 ## don't add "groups" when connecting directly to google
 # kube_oidc_groups_claim: "groups"
 kube_oidc_extra_scopes: []

--- a/migration/v2.19.x-ck8sx-v2.20.x-ck8s1/upgrade-cluster.md
+++ b/migration/v2.19.x-ck8sx-v2.20.x-ck8s1/upgrade-cluster.md
@@ -1,0 +1,28 @@
+# Upgrade v2.19.x-ck8sx to v2.20.x-ck8s1
+
+1. Checkout the new release: `git checkout v2.20.x-ck8s1`
+
+1. Switch to the correct remote: `git submodule sync`
+
+1. Update the kubespray submodule: `git submodule update --init --recursive`
+
+1. set the values for `kubeconfig_cluster_name` in both `sc-config/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml` and `wc-config/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml` to the corresponding name like below:
+
+    ```yaml
+    kubeconfig_cluster_name: <CHANGE-ME-ENVIRONMENT-NAME-sc>
+    kubeconfig_cluster_name: <CHANGE-ME-ENVIRONMENT-NAME-wc>
+    ```
+
+1. Upgrade the cluster to a new kubernetes version:
+
+    ```bash
+    ./bin/ck8s-kubespray run-playbook sc upgrade-cluster.yml -b
+    ./bin/ck8s-kubespray run-playbook wc upgrade-cluster.yml -b
+    ```
+
+1. generate updated kubeconfigs:
+
+    ```bash
+    ./bin/ck8s-kubespray run-playbook sc ../playbooks/kubeconfig.yml -b
+    ./bin/ck8s-kubespray run-playbook wc ../playbooks/kubeconfig.yml -b
+    ```

--- a/playbooks/templates/kube_config_oidc.yml.j2
+++ b/playbooks/templates/kube_config_oidc.yml.j2
@@ -3,18 +3,18 @@ clusters:
 -   cluster:
         certificate-authority-data: {{ ca_cert.stdout }}
         server: https://{{ kube_oidc_apiserver_endpoint | default(kube_apiserver_access_address) }}:{{ kube_oidc_apiserver_port | default(kube_apiserver_port) }}
-    name: {{ cluster_name }}
+    name: {{ kubeconfig_cluster_name }}
 contexts:
 -   context:
-        cluster: {{ cluster_name }}
+        cluster: {{ kubeconfig_cluster_name }}
         namespace: default
-        user: admin@{{ cluster_name }}
-    name: {{ cluster_name }}
-current-context: {{ cluster_name }}
+        user: admin@{{ kubeconfig_cluster_name }}
+    name: {{ kubeconfig_cluster_name }}
+current-context: {{ kubeconfig_cluster_name }}
 kind: Config
 preferences: {}
 users:
--   name: admin@{{ cluster_name }}
+-   name: admin@{{ kubeconfig_cluster_name }}
     user:
         exec:
             apiVersion: client.authentication.k8s.io/v1beta1


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix cluster.local in kubeconfigs
**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [ ] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
