### PR TITLE
upcloud csi driver: bump version to v0.3.3

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - pre-commit rev update to `2.2.0-rc.1`
 - Scripts are now using yq version 4
+- Bumped upcloud csi driver to `v0.3.3`
 
 ## Fixed
 - Fixed multiple kube-bench fails (01.03.07, 01.04.01, 01.04.02)

--- a/migration/v2.19.x-ck8sx-v2.20.x-ck8s1/upgrade-cluster.md
+++ b/migration/v2.19.x-ck8sx-v2.20.x-ck8s1/upgrade-cluster.md
@@ -13,6 +13,51 @@
     kubeconfig_cluster_name: <CHANGE-ME-ENVIRONMENT-NAME-wc>
     ```
 
+1. upcloud environments remove or update storage class specification
+    The new default in the config is the following
+
+    ```
+    storage_classes:
+       - name: standard
+         is_default: true
+         expand_persistent_volumes: true
+         parameters:
+           tier: maxiops
+       - name: hdd
+         is_default: false
+         expand_persistent_volumes: true
+         parameters:
+           tier: hdd
+    ```
+
+    Remove or update the `storage_classes` in both `sc-config/group_vars/k8s_cluster/ck8s-k8s-cluster-upcloud.yaml` and `wc-config/group_vars/k8s_cluster/ck8s-k8s-cluster-upcloud.yaml` to work with the new format
+
+    Update example:
+    Old format:
+
+    ```
+     expand_persistent_volumes: true
+     parameters:
+         tier: maxiops
+      storage_classes:
+            - name: standard
+              is_default: true
+    ```
+
+    To new format
+
+    ```diff
+    - expand_persistent_volumes: true
+    - parameters:
+    -     tier: maxiops
+      storage_classes:
+            - name: standard
+              is_default: true
+    +         expand_persistent_volumes: true
+    +         parameters:
+    +             tier: maxiops
+    ```
+
 1. Upgrade the cluster to a new kubernetes version:
 
     ```bash


### PR DESCRIPTION
**What this PR does / why we need it**:

Bump upcloud csi driver

**Which issue this PR fixes**: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [ ] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
