### PR TITLE
config: changed variable for upgrading cp nodes without external ip

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Changed a Kubespray variable which is required for upgrading clusters on cloud providers that don't have external IPs on their control plane nodes.

--- a/config/common/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml
+++ b/config/common/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml
@@ -125,3 +125,8 @@ kube_kubeadm_scheduler_extra_args:
     profiling: false
 
 kube_controller_manager_bind_address: 127.0.0.1
+
+kubelet_secure_addresses: >-
+  {%- for host in groups['kube_control_plane'] -%}
+    {{ hostvars[host]['ip'] | default(fallback_ips[host]) }}{{ ' ' if not loop.last else '' }}
+  {%- endfor -%}

--- a/migration/v2.19.x-ck8sx-v2.20.x-ck8s1/upgrade-cluster.md
+++ b/migration/v2.19.x-ck8sx-v2.20.x-ck8s1/upgrade-cluster.md
@@ -20,12 +20,13 @@ These steps will not disrupt the environment and can be done ahead of a maintena
     +    profiling: false
 
     +kube_controller_manager_bind_address: 127.0.0.1
-    ```
 
-1. Add the following snippet at the end of both `sc-config/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml` and `wc-config/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml`
-
-    ```diff
     +calico_pool_blocksize: 24
+
+    +kubelet_secure_addresses: >-
+    +  {%- for host in groups['kube_control_plane'] -%}
+    +    {{ hostvars[host]['ip'] | default(fallback_ips[host]) }}{{ ' ' if not loop.last else '' }}
+    +  {%- endfor -%}
     ```
 
 1. set the values for `kubeconfig_cluster_name` in both `sc-config/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml` and `wc-config/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml` to the corresponding name like below:


### PR DESCRIPTION
**What this PR does / why we need it**:

Changed a Kubespray variable which is required for upgrading clusters on cloud providers that don't have external IPs on their control plane nodes. i.e. Safespring

**Checklist:**

- [X] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [ ] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
