### PR TITLE
kubespray: Updated to 2.20.0 with new terraform changes

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,3 +1,11 @@
+### Release notes
+
+- This requires at least terraform 0.14.0
+
 ### Fixed
 
 - Changed a Kubespray variable which is required for upgrading clusters on cloud providers that don't have external IPs on their control plane nodes.
+
+### Changed
+
+- Changed terraform scripts for openstack to be able to setup additional server groups and override variables per instance.

--- a/migration/v2.20.0-ck8s2-v2.20.0-ck8s3/upgrade-cluster.md
+++ b/migration/v2.20.0-ck8s2-v2.20.0-ck8s3/upgrade-cluster.md
@@ -1,0 +1,9 @@
+# Upgrade v2.20.0-ck8s2 to v2.20.0-ck8s3
+
+1. Checkout the new release: `git checkout v2.20.0-ck8s3`
+
+1. Switch to the correct remote: `git submodule sync`
+
+1. Update the kubespray submodule: `git submodule update --init --recursive`
+
+    NOTE: This update requires a newer version of terraform, so make sure that you're using terraform 0.14 or later


### PR DESCRIPTION
**What this PR does / why we need it**:

Updated kubespray to use our fork with 2.20 + terraform changes for node override variables and additional server groups

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #174 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [ ] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
