### PR TITLE
rook-ceph: Enabled ceph dashboard

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -9,3 +9,4 @@
 ### Changed
 
 - Changed terraform scripts for openstack to be able to setup additional server groups and override variables per instance.
+- Enabled the `ceph` dashboard for better visibility and troubleshooting of `rook-ceph`

--- a/rook/cluster.yaml
+++ b/rook/cluster.yaml
@@ -20,7 +20,7 @@ spec:
     - name: pg_autoscaler
       enabled: true
   dashboard:
-    enabled: false
+    enabled: true
   monitoring:
     # requires Prometheus operator CRDs to be pre-installed
     enabled: false


### PR DESCRIPTION
**What this PR does / why we need it**: Enabled ceph dashboard as it gives better detailed visibility and troubleshooting ceph cluster . It does't uses the extra resources/pods and run on the same pod `mgr` with different port `7000` with separate service `rook-ceph-mgr-dashboard`

![image](https://user-images.githubusercontent.com/75951259/199703001-a2f835e3-6e5e-4421-9e18-5886a99724a1.png)


**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [X] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [X] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
