### PR TITLE
Upgrade ceph

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,6 +1,7 @@
 ### Release notes
 
 - This requires at least terraform 0.14.0
+- If you are using the rook-ceph operator you can read the [migration docs](rook/migration/rook-1.5.x-rook-1.10.5/upgrade.md) on how to upgrade these components.
 
 ### Fixed
 
@@ -10,3 +11,4 @@
 
 - Changed terraform scripts for openstack to be able to setup additional server groups and override variables per instance.
 - Enabled the `ceph` dashboard for better visibility and troubleshooting of `rook-ceph`
+- Upgraded rook-ceph operator to `v1.10.5` and ceph to `v17.2.5`

--- a/rook/deploy-rook.sh
+++ b/rook/deploy-rook.sh
@@ -9,7 +9,7 @@ helm repo add rook-release https://charts.rook.io/release
 namespace="rook-ceph"
 release_name="rook-ceph"
 chart="rook-release/rook-ceph"
-chart_version="v1.5.3"
+chart_version="v1.10.5"
 
 # Install rook operator
 kubectl create namespace "${namespace}" --dry-run -o yaml | kubectl apply -f -

--- a/rook/migration/rook-1.5.x-rook-1.10.5/cluster-16.2.10.yaml
+++ b/rook/migration/rook-1.5.x-rook-1.10.5/cluster-16.2.10.yaml
@@ -1,5 +1,3 @@
-# See https://rook.io/docs/rook/v1.10/Getting-Started/example-configurations/#cluster-crd and
-# https://github.com/rook/rook/blob/v1.10.5/deploy/examples/cluster.yaml for examples and configuration values
 apiVersion: ceph.rook.io/v1
 kind: CephCluster
 metadata:
@@ -7,7 +5,7 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: quay.io/ceph/ceph:v17.2.5
+    image: quay.io/ceph/ceph:v16.2.10
     allowUnsupported: false
   dataDirHostPath: /var/lib/rook
   skipUpgradeChecks: false
@@ -22,6 +20,7 @@ spec:
   dashboard:
     enabled: true
   monitoring:
+    # requires Prometheus operator CRDs to be pre-installed
     enabled: false
   crashCollector:
     disable: false
@@ -44,10 +43,12 @@ spec:
       requests:
         cpu: "500m"
         memory: "1Gi"
+#    prepareosd:
     crashcollector:
       requests:
         cpu: "1m"
         memory: "15Mi"
+#    cleanup:
   removeOSDsIfOutAndSafeToRemove: false
   storage:
     useAllNodes: true

--- a/rook/migration/rook-1.5.x-rook-1.10.5/cluster-17.2.5.yaml
+++ b/rook/migration/rook-1.5.x-rook-1.10.5/cluster-17.2.5.yaml
@@ -1,5 +1,3 @@
-# See https://rook.io/docs/rook/v1.10/Getting-Started/example-configurations/#cluster-crd and
-# https://github.com/rook/rook/blob/v1.10.5/deploy/examples/cluster.yaml for examples and configuration values
 apiVersion: ceph.rook.io/v1
 kind: CephCluster
 metadata:
@@ -22,6 +20,7 @@ spec:
   dashboard:
     enabled: true
   monitoring:
+    # requires Prometheus operator CRDs to be pre-installed
     enabled: false
   crashCollector:
     disable: false
@@ -44,10 +43,12 @@ spec:
       requests:
         cpu: "500m"
         memory: "1Gi"
+#    prepareosd:
     crashcollector:
       requests:
         cpu: "1m"
         memory: "15Mi"
+#    cleanup:
   removeOSDsIfOutAndSafeToRemove: false
   storage:
     useAllNodes: true

--- a/rook/migration/rook-1.5.x-rook-1.10.5/upgrade.md
+++ b/rook/migration/rook-1.5.x-rook-1.10.5/upgrade.md
@@ -1,0 +1,152 @@
+# Upgrade Rook-Ceph operator and Ceph
+
+This doc will guide you through upgrading the Rook-Ceph operator from version `v1.5` to `v1.10`, and Ceph from `v15` to `v17`.
+
+## Steps
+
+### Prerequisites
+
+```bash
+# Go to rook directory in compliantkubernetes-kubespray
+cd /path/to/compliantkubernetes-kubespray/rook
+
+# Add and update rook helm repo
+helm repo add rook-release https://charts.rook.io/release && helm repo update
+
+# Set variables
+namespace="rook-ceph"
+release_name="rook-ceph"
+chart="rook-release/rook-ceph"
+
+# Set kubeconfig
+export KUBECONFIG=/path/to/kubeconfig
+```
+
+Before all upgrades make sure that the Ceph cluster is in a healthy state.
+You can find some details on how to verify the health [here](https://rook.io/docs/rook/v1.10/Upgrade/health-verification/#pods-all-running).
+
+After an upgrade you should also verify the status of the components before proceeding.
+
+Here are some useful commands that can be used to check the version of the components
+
+```bash
+kubectl -n ${namespace} exec -it deployments/rook-ceph-tools -- ceph -s
+
+kubectl -n ${namespace} get deployments -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \trook-version="}{.metadata.labels.rook-version}{"\n"}{end}'
+
+kubectl -n ${namespace} get jobs -o jsonpath='{range .items[*]}{.metadata.name}{"  \tsucceeded: "}{.status.succeeded}{"      \trook-version="}{.metadata.labels.rook-version}{"\n"}{end}'
+
+watch --exec kubectl -n ${namespace} get deployments -l rook_cluster=${namespace} -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \trook-version="}{.metadata.labels.rook-version}{"\n"}{end}'
+```
+
+### Operator to v1.6
+
+Go [here](https://rook.io/docs/rook/v1.6/ceph-upgrade.html) for the official upgrade docs.
+
+```bash
+chart_version="v1.6.11"
+
+# Check diff
+helm diff upgrade --install --namespace "${namespace}" "${release_name}" "${chart}" \
+  --version "${chart_version}" --values operator-values.yaml
+
+# Upgrade
+helm upgrade --install --namespace "${namespace}" "${release_name}" "${chart}" \
+  --version "${chart_version}" --values operator-values.yaml --wait
+```
+
+### Operator to v1.7
+
+```bash
+chart_version="v1.7.11"
+
+# Check diff
+helm diff upgrade --install --namespace "${namespace}" "${release_name}" "${chart}" \
+  --version "${chart_version}" --values operator-values.yaml
+
+# Upgrade
+helm upgrade --install --namespace "${namespace}" "${release_name}" "${chart}" \
+  --version "${chart_version}" --values operator-values.yaml --wait
+```
+
+### Ceph to v16
+
+Skip this step if you are already running Ceph `v16`.
+
+If you are using a custom manifest for your CephCluster deployment you need to update `spec.cephVersion.image` to `quay.io/ceph/ceph:v16.2.10`, and apply the changes.
+
+If you have deployed ceph using the provided `cluster.yaml` from a previous version of this repo, you can simply deploy the manifest `migration/rook-1.5.x-rook-1.10.5/cluster-16.2.10.yaml`
+
+```bash
+kubectl apply -f migration/rook-1.5.x-rook-1.10.5/cluster-16.2.10.yaml
+```
+
+If you see this or a similar message
+
+> HEALTH_WARN all OSDs are running pacific or later but require_osd_release < pacific
+
+you need to execute the following command
+
+```bash
+kubectl -n ${namespace} exec -it deployments/rook-ceph-tools -- ceph osd require-osd-release pacific
+```
+
+### Operator to v1.8
+
+```bash
+chart_version="1.8.10"
+
+# Check diff
+helm diff upgrade --install --namespace "${namespace}" "${release_name}" "${chart}" \
+  --version "${chart_version}" --values operator-values.yaml
+
+# Upgrade
+helm upgrade --install --namespace "${namespace}" "${release_name}" "${chart}" \
+  --version "${chart_version}" --values operator-values.yaml --wait
+```
+
+### Operator to v1.9
+
+```bash
+chart_version="1.9.12"
+
+# Check diff
+helm diff upgrade --install --namespace "${namespace}" "${release_name}" "${chart}" \
+  --version "${chart_version}" --values operator-values.yaml
+
+# Upgrade
+helm upgrade --install --namespace "${namespace}" "${release_name}" "${chart}" \
+  --version "${chart_version}" --values operator-values.yaml --wait
+```
+
+### Operator to 1.10
+
+```bash
+chart_version="1.10.5"
+
+# Check diff
+helm diff upgrade --install --namespace "${namespace}" "${release_name}" "${chart}" \
+  --version "${chart_version}" --values operator-values.yaml
+
+# Upgrade
+helm upgrade --install --namespace "${namespace}" "${release_name}" "${chart}" \
+  --version "${chart_version}" --values operator-values.yaml --wait
+```
+
+### Ceph to v17
+
+Skip this step if you are already running Ceph `v17`.
+
+If you are using a custom manifest for your CephCluster deployment you need to update `spec.cephVersion.image` to `quay.io/ceph/ceph:v17.2.5`, and apply the changes.
+
+If you have deployed ceph using the provided `cluster.yaml` from a previous version of this repo, you can simply deploy the manifest `migration/rook-1.5.x-rook-1.10.5/cluster-17.2.5.yaml`
+
+```bash
+kubectl apply -f migration/rook-1.5.x-rook-1.10.5/cluster-17.2.5.yaml
+```
+
+### Update rook-ceph-tools
+
+```bash
+kubectl apply -f toolbox-deploy.yaml
+```

--- a/rook/operator-values.yaml
+++ b/rook/operator-values.yaml
@@ -1,3 +1,5 @@
+# For a full list of values see
+# https://github.com/rook/rook/blob/v1.10.5/deploy/charts/rook-ceph/values.yaml
 csi:
   enableCephfsDriver: false
   #provisionerTolerations:

--- a/rook/toolbox-deploy.yaml
+++ b/rook/toolbox-deploy.yaml
@@ -1,8 +1,8 @@
 # This file was originally downloaded from https://github.com/rook/rook/blob/c890710b635e2cd2ae64c08bac0621d89e79c0fc/deploy/examples/toolbox.yaml
 #
-# The following changes were performed:
-# - use stable container image, i.e., 'v1.8.6' instead of master
-# - add resource limits
+# The following changes have been performed:
+# - use stable container image
+# - add resource requests and limits
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -23,7 +23,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: rook-ceph-tools
-          image: rook/ceph:v1.8.6
+          image: rook/ceph:v1.10.5
           command: ["/bin/bash"]
           args: ["-m", "-c", "/usr/local/bin/toolbox.sh"]
           imagePullPolicy: IfNotPresent
@@ -50,8 +50,11 @@ spec:
               mountPath: /etc/rook
           resources:
             requests:
-             cpu: "5m"
-             memory: "10Mi"
+             cpu: 5m
+             memory: 10Mi
+            limits:
+             cpu: 100m
+             memory: 100Mi
       volumes:
         - name: mon-endpoint-volume
           configMap:


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrades the rook-ceph operator and ceph.

**Which issue this PR fixes**:
Fixes #131 

**Special notes for reviewer**:
- I will take a look at the prometheus alerts in apps in a while.

- I did not really find that we needed to modify anything in the operator values or the cluster manifest.

- I decided that it was safest to upgrade the operator one step at a time as it is then easier to debug and recover if a problem were to occur.

**Checklist:**

- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [ ] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
