### PR TITLE
Remove rest of docker files

### DIFF
--- a/migration/v2.18.0-ck8s1-v2.19.x-ck8s1/migrate-to-containerd.yml
+++ b/migration/v2.18.0-ck8s1-v2.19.x-ck8s1/migrate-to-containerd.yml
@@ -55,6 +55,18 @@
           ansible.builtin.debug:
             var: clusterymloutput
 
+        - name: Delete remaining docker files
+          file:
+            state: absent
+            path: "{{ item }}"
+          with_items:
+            - '/var/lib/docker'
+            - '/var/lib/dockershim'
+            - '/etc/systemd/system/docker.service.d'
+            - '/etc/systemd/system/docker.service'
+            - '/etc/systemd/system/docker.socket'
+            - '/etc/init.d/docker'
+
         - name: annotate nodes with cri sock #The annotation is required by kubeadm to follow through future cluster upgrades.
           command: kubectl annotate node {{hostname.stdout}} --overwrite kubeadm.alpha.kubernetes.io/cri-socket=/var/run/containerd/containerd.sock
           delegate_to: "{{groups['kube_control_plane'][0]}}"


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove the rest of docker files after migrating to containerd

**Which issue this PR fixes**: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [ ] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
