### PR TITLE
migration: Update containerd migration

### DIFF
--- a/migration/v2.18.0-ck8s1-v2.19.x-ck8s1/migrate-to-containerd.yml
+++ b/migration/v2.18.0-ck8s1-v2.19.x-ck8s1/migrate-to-containerd.yml
@@ -55,12 +55,11 @@
           ansible.builtin.debug:
             var: clusterymloutput
 
-        - name: Delete remaining docker files
+        - name: Delete docker service files
           file:
             state: absent
             path: "{{ item }}"
           with_items:
-            - '/var/lib/docker'
             - '/var/lib/dockershim'
             - '/etc/systemd/system/docker.service.d'
             - '/etc/systemd/system/docker.service'
@@ -128,6 +127,15 @@
           until: kubelet_ready.rc == 0
           retries: 30
           delay: 3
+
+        - name: Delete remaining docker files
+          file:
+            state: absent
+            path: "{{ item }}"
+          with_items:
+            - '/var/lib/docker/image'
+            - '/var/lib/docker/overlay2'
+            - '/var/lib/docker/volumes'
 
         - name: uncordon node
           command: kubectl uncordon {{hostname.stdout}} --kubeconfig /etc/kubernetes/admin.conf


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove `/var/lib/docker` after reboot

**Special notes for reviewer**:
I haven't tested it, but I think this should work?

**Checklist:**

- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [ ] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
