### PR TITLE
all: added get-requirements file to standardize terraform

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,18 @@ The user-facing API changes more rarely, usually as a result of a Kubernetes ver
 - `conformance-tests`: ck8s conformance tests for bare metal machines
 - `kubespray`: git submodule of the kubespray repository
 
+## Setup
+
+### Requirements
+
+[terraform](https://github.com/hashicorp/terraform/releases) (tested with 1.2.9)
+
+Installs requirements using the ansible playbook `get-requirements.yaml`
+
+```bash
+ansible-playbook -e 'ansible_python_interpreter=/usr/bin/python3' --ask-become-pass --connection local --inventory 127.0.0.1, get-requirements.yaml
+```
+
 ## Quick start
 
 1. Init the kubespray config in your config path

--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -12,3 +12,7 @@
 - Changed terraform scripts for openstack to be able to setup additional server groups and override variables per instance.
 - Enabled the `ceph` dashboard for better visibility and troubleshooting of `rook-ceph`
 - Upgraded rook-ceph operator to `v1.10.5` and ceph to `v17.2.5`
+
+### Added
+
+Added a get-requirements file to standardize which terraform version to use, `1.2.9`.

--- a/get-requirements.yaml
+++ b/get-requirements.yaml
@@ -1,0 +1,16 @@
+  - name: Download compliantkubernetes-kubespray requirements
+    hosts: localhost
+    vars:
+      install_path: /usr/local/bin
+      install_user: "{{ lookup('env','USER') }}"
+      terraform_version: 1.2.9
+    connection: local
+    become: yes
+    become_user: root
+    tasks:
+    - name: Get terraform
+      unarchive:
+        src: "https://releases.hashicorp.com/terraform/{{ terraform_version }}/terraform_{{ terraform_version }}_linux_amd64.zip"
+        dest: "{{ install_path }}"
+        mode: 0775
+        remote_src: yes


### PR DESCRIPTION
**What this PR does / why we need it**:

We had a discussion in the office and thought it make more sense to go with terraform `1.2.9` for now, that way we don't have to make a new patch release for ck8s-kubespray to fix the experimental feature issue we ran into with terraform `1.3+`. This way we are also closer to what the upstream kubespray repo is using.

Tested running Kubespray on `v2.20.0-ck8s3` with this terraform version (`1.2.9`) and I had no issues.

**Which issue this PR fixes** : fixes #248 

**Checklist:**

- [X] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [ ] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
