### PR TITLE
config: add ntp.se as ntp server as migration step

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -15,4 +15,5 @@
 
 ### Added
 
-Added a get-requirements file to standardize which terraform version to use, `1.2.9`.
+- Added a get-requirements file to standardize which terraform version to use, `1.2.9`.
+- Add ntp.se as ntp server as standard

--- a/config/common/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml
+++ b/config/common/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml
@@ -130,3 +130,20 @@ kubelet_secure_addresses: >-
   {%- for host in groups['kube_control_plane'] -%}
     {{ hostvars[host]['ip'] | default(fallback_ips[host]) }}{{ ' ' if not loop.last else '' }}
   {%- endfor -%}
+
+ntp_enabled: true
+ntp_manage_config: true
+ntp_servers:
+  - "gbg1.ntp.netnod.se iburst"
+  - "gbg2.ntp.netnod.se iburst"
+  - "lul1.ntp.netnod.se iburst"
+  - "lul2.ntp.netnod.se iburst"
+  - "mmo1.ntp.netnod.se iburst"
+  - "mmo2.ntp.netnod.se iburst"
+  - "sth1.ntp.netnod.se iburst"
+  - "sth2.ntp.netnod.se iburst"
+  - "sth3.ntp.netnod.se iburst"
+  - "sth4.ntp.netnod.se iburst"
+  - "svl1.ntp.netnod.se iburst"
+  - "svl2.ntp.netnod.se iburst"
+ntp_timezone: "Etc/UTC"

--- a/migration/v2.20.0-ck8sx-v2.21.0-ck8sx/upgrade-cluster.md
+++ b/migration/v2.20.0-ck8sx-v2.21.0-ck8sx/upgrade-cluster.md
@@ -1,0 +1,42 @@
+# Upgrade v2.20.0-ck8sx to v2.21.0-ck8sx
+
+1. Checkout the new release: `git checkout v2.21.0-ck8sx`
+
+1. Switch to the correct remote: `git submodule sync`
+
+1. Update the kubespray submodule: `git submodule update --init --recursive`
+
+1. Add the following snippet at the end of both `sc-config/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml` and `wc-config/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml`
+
+    This enables NTP service and with multiple NTP servers, specificity in sweden.
+    You can visit [www.ntppool.org](https://www.ntppool.org/zone/@) to find other ntp pools if you are in other parts of the world.
+
+    ```yaml
+    ntp_enabled: true
+    ntp_manage_config: true
+    ntp_servers:
+    - "gbg1.ntp.netnod.se iburst"
+    - "gbg2.ntp.netnod.se iburst"
+    - "lul1.ntp.netnod.se iburst"
+    - "lul2.ntp.netnod.se iburst"
+    - "mmo1.ntp.netnod.se iburst"
+    - "mmo2.ntp.netnod.se iburst"
+    - "sth1.ntp.netnod.se iburst"
+    - "sth2.ntp.netnod.se iburst"
+    - "sth3.ntp.netnod.se iburst"
+    - "sth4.ntp.netnod.se iburst"
+    - "svl1.ntp.netnod.se iburst"
+    - "svl2.ntp.netnod.se iburst"
+    ntp_timezone: "Etc/UTC"
+    ```
+
+## Disruptive steps
+
+These steps will cause disruptions in the environment.
+
+1. Upgrade the cluster to a new kubernetes version:
+
+    ```bash
+    ./bin/ck8s-kubespray run-playbook sc upgrade-cluster.yml -b
+    ./bin/ck8s-kubespray run-playbook wc upgrade-cluster.yml -b
+    ```


### PR DESCRIPTION
**What this PR does / why we need it**:

Add ntp.se as ntp server

**Which issue this PR fixes**: fixes #250 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

After applying one can check ntp on the nodes:

```bash
ntpq -pn
     remote           refid      st t when poll reach   delay   offset  jitter
==============================================================================
 gbg1.ntp.netnod .POOL.          16 p    -   64    0    0.000    0.000   0.000
 gbg2.ntp.netnod .POOL.          16 p    -   64    0    0.000    0.000   0.000
 lul1.ntp.netnod .POOL.          16 p    -   64    0    0.000    0.000   0.000
 lul2.ntp.netnod .POOL.          16 p    -   64    0    0.000    0.000   0.000
 mmo1.ntp.netnod .POOL.          16 p    -   64    0    0.000    0.000   0.000
 mmo2.ntp.netnod .POOL.          16 p    -   64    0    0.000    0.000   0.000
 sth1.ntp.netnod .POOL.          16 p    -   64    0    0.000    0.000   0.000
 sth2.ntp.netnod .POOL.          16 p    -   64    0    0.000    0.000   0.000
 sth3.ntp.netnod .POOL.          16 p    -   64    0    0.000    0.000   0.000
 sth4.ntp.netnod .POOL.          16 p    -   64    0    0.000    0.000   0.000
 svl1.ntp.netnod .POOL.          16 p    -   64    0    0.000    0.000   0.000
 svl2.ntp.netnod .POOL.          16 p    -   64    0    0.000    0.000   0.000
-194.58.206.20   .PPS.            1 u   61   64  377   21.952   -1.358   0.403
-194.58.206.148  .PPS.            1 u   45   64  377   21.868   -1.353   0.382
-194.58.204.20   .PPS.            1 u   55   64  377   20.164   -1.656   1.578
+194.58.204.148  .PPS.            1 u   54   64  377   18.601   -0.196   0.577
+194.58.202.20   .PPS.            1 u   60   64  377   11.828    0.191   0.592
-194.58.202.148  .PPS.            1 u   47   64  377   11.859   -0.528   0.311
*194.58.207.20   .PPS.            1 u   51   64  377   11.581   -0.473   0.300
```

```bash
ntpq -c rv
associd=0 status=0615 leap_none, sync_ntp, 1 event, clock_sync,
version="ntpd 4.2.8p12@1.3728-o (1)", processor="x86_64",
system="Linux/5.4.0-26-generic", leap=00, stratum=2, precision=-24,
rootdelay=11.581, rootdisp=7.012, refid=194.58.207.20,
reftime=e7724195.db6dd5be  Wed, Jan 18 2023  9:59:49.857,
clock=e77242ac.63cc8ad8  Wed, Jan 18 2023 10:04:28.389, peer=53691, tc=6,
mintc=3, offset=-0.175057, frequency=25.777, sys_jitter=0.037477,
clk_jitter=9.676, clk_wander=0.071
```

```bash
ntptime
ntp_gettime() returns code 0 (OK)
  time e77244d4.839ffd60  Wed, Jan 18 2023 10:13:40.514, (.514160397),
  maximum error 87450 us, estimated error 7921 us, TAI offset 0
ntp_adjtime() returns code 0 (OK)
  modes 0x0 (),
  offset -614.212 us, frequency 25.509 ppm, interval 1 s,
  maximum error 87450 us, estimated error 7921 us,
  status 0x2001 (PLL,NANO),
  time constant 7, precision 0.001 us, tolerance 500 ppm,
```


**Checklist:**

- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [x] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
