### PR TITLE
bin: fix typos in status messages

### DIFF
--- a/bin/apply.bash
+++ b/bin/apply.bash
@@ -36,4 +36,4 @@ ansible-playbook -i "${config[inventory_file]}" ../playbooks/cluster_admin_rbac.
 
 popd
 
-log_info "Cluster created sucessfully!"
+log_info "Cluster created successfully!"

--- a/bin/remove-node.bash
+++ b/bin/remove-node.bash
@@ -32,7 +32,7 @@ if [ -z "${CK8S_KUBESPRAY_NO_VENV+x}" ]; then
     pip install -r requirements.txt
 fi
 
-log_info "Remvoing node: $node_name"
+log_info "Removing node: $node_name"
 
 # shellcheck disable=SC2145
 log_info Executing \"ansible-playbook -i "${config[inventory_file]}" "${playbook}" -b --extra-vars="node=${node_name}" "${@}"\"
@@ -41,4 +41,4 @@ ansible-playbook -i "${config[inventory_file]}" "${playbook}" -b --extra-vars="n
 
 popd
 
-log_info "Kubespray done - playbook ${playbook} ran sucessfully!"
+log_info "Kubespray done - playbook ${playbook} ran successfully!"

--- a/bin/run-playbook.bash
+++ b/bin/run-playbook.bash
@@ -39,4 +39,4 @@ popd
 
 log_info "Kubespray done"
 
-log_info "Playbook ${playbook} ran sucessfully!"
+log_info "Playbook ${playbook} ran successfully!"


### PR DESCRIPTION
**What this PR does / why we need it**: Fixed a few typos in messages that are shown when running `bin/ck8s-kubespray` commands.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [X] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [X] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
