### PR TITLE
docs: added prompt to migration doc creation script

### DIFF
--- a/migration/create-migration-document.sh
+++ b/migration/create-migration-document.sh
@@ -17,6 +17,17 @@ fi
 here="$(dirname "$(readlink -f "$0")")"
 export old_version="${1}"
 export new_version="${2}"
+
+echo "You are about to create the migration documentation for versions"
+echo "  from: ${old_version}"
+echo "  to:   ${new_version}"
+echo -n "Are you sure you want to continue [y/N]: "
+read -r reply
+if [[ ! "${reply}" =~ ^[yY]$ ]]; then
+  echo "Aborting..."
+  exit 0
+fi
+
 folder_name="${here}/${old_version}-${new_version}"
 
 if [ -d "${folder_name}" ]; then

--- a/release/README.md
+++ b/release/README.md
@@ -51,7 +51,7 @@ The releases will have the following version string: `<kubespray-version>-<ck8s-
     **NOTE**: All changes made in QA should be added to `CHANGELOG.md` and **NOT** `WIP-CHANGELOG.md`.
     Also, make sure to not merge any fixes into `release-<kubespray-version>` on this step.
 
-    If there is no migration document, create one as describe [here](../migration/README.md).
+    If there is no migration document, create one as described [here](../migration/README.md). If a migration document already exists, make sure that it follows [this template](../migration/template/upgrade-cluster.md).
 
 1. When the QA is finished, create the release tag.
 
@@ -128,7 +128,7 @@ The releases will have the following version string: `<kubespray-version>-<ck8s-
     **NOTE**: All changes made in QA should be added to `CHANGELOG.md` and **NOT** `WIP-CHANGELOG.md`.
     Also, make sure to not merge any fixes into `release-<kubespray-version>` on this step.
 
-    If any migration steps are required for the patch, create a migration document as describe [here](../migration/README.md).
+    If any migration steps are required for the patch, create a migration document as described [here](../migration/README.md). If a migration document already exists, make sure that it follows [this template](../migration/template/upgrade-cluster.md).
 
 1. When the QA is finished, create the release tag and push it.
 


### PR DESCRIPTION
**What this PR does / why we need it**:

**Checklist:**

- [X] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [X] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
