### PR TITLE
bin: defaulted to serial execution in upgrade playbook

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -12,6 +12,7 @@
 - Changed terraform scripts for openstack to be able to setup additional server groups and override variables per instance.
 - Enabled the `ceph` dashboard for better visibility and troubleshooting of `rook-ceph`
 - Upgraded rook-ceph operator to `v1.10.5` and ceph to `v17.2.5`
+- Now defaulting to serial execution when running the upgrade playbook.
 
 ### Added
 

--- a/bin/run-playbook.bash
+++ b/bin/run-playbook.bash
@@ -33,7 +33,7 @@ if [ -z "${CK8S_KUBESPRAY_NO_VENV+x}" ]; then
 fi
 
 log_info "Running kubespray"
-ansible-playbook -i "${config[inventory_file]}" "${playbook}" "${@}"
+ansible-playbook -i "${config[inventory_file]}" "-e serial=1" "${playbook}" "${@}"
 
 popd
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Tested adding 10 worker nodes to a cluster and ran the upgrade playbook (with --tags=network) with and without this change. It did these plays ([this](https://github.com/kubernetes-sigs/kubespray/blob/df1bdb22928312cd5703a4be5017d9d6d50dc875/upgrade-cluster.yml#L109) & [this](https://github.com/kubernetes-sigs/kubespray/blob/df1bdb22928312cd5703a4be5017d9d6d50dc875/upgrade-cluster.yml#L122)) one worker node at a time when setting `-e serial=1` and two at a time without it.

I also tried running another playbook `scale.yml` via the `run-playbook` binary and it worked normally when setting `-e serial=1` as it doesn't use this variable.

**Which issue this PR fixes** : fixes #208 

**Checklist:**

- [X] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [X] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
