### PR TITLE
Updated kubespray to support network id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Compliant Kubernetes Kubespray changelog
 <!-- BEGIN TOC -->
+- [v2.20.0-ck8s4](#v2200-ck8s4---2023-03-06)
 - [v2.20.0-ck8s3](#v2200-ck8s3---2022-10-31)
 - [v2.20.0-ck8s2](#v2200-ck8s2---2022-10-24)
 - [v2.20.0-ck8s1](#v2200-ck8s1---2022-10-10)
@@ -12,6 +13,13 @@
 - [v2.16.0-ck8s1](#v2160-ck8s1---2021-07-02)
 - [v2.15.0-ck8s1](#v2150-ck8s1---2021-05-27)
 <!-- END TOC -->
+
+-------------------------------------------------
+## v2.20.0-ck8s4 - 2023-03-06
+
+### Changed
+
+- Updated kubespray to include support for network id for individual nodes.
 
 -------------------------------------------------
 ## v2.20.0-ck8s3 - 2022-10-31


### PR DESCRIPTION
**What this PR does / why we need it**:

For metallb we need to have support to override network ID on individual nodes which was missed when we did the last patch. So this would fix that. But this is part of the kubespray 2.21 release so we don't need to fix it on main

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [ ] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
