### PR TITLE
bin: changed to inventory hostnames in reboot script

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,0 +1,2 @@
+### Fixed
+Reboot scripts uses inventory hostnames instead of machine hostnames

--- a/playbooks/reboot_nodes.yml
+++ b/playbooks/reboot_nodes.yml
@@ -25,15 +25,8 @@
       when: "manual_prompt | default(false) | bool and 'reboot_required_file' in hostvars[item] and hostvars[item]['reboot_required_file'].stat.exists"
       with_items: "{{ play_hosts }}"
 
-    - name: hostname
-      shell: echo $HOSTNAME
-      args:
-        executable: /bin/bash
-      register: hostname
-      when: reboot_required_file.stat.exists
-
     - name: drain node
-      command: kubectl drain {{hostname.stdout}} --ignore-daemonsets=true --delete-emptydir-data=true --force=true --kubeconfig /etc/kubernetes/admin.conf
+      command: kubectl drain {{ inventory_hostname }} --ignore-daemonsets=true --delete-emptydir-data=true --force=true --kubeconfig /etc/kubernetes/admin.conf
       delegate_to: "{{groups['kube_control_plane'][0]}}"
       when: reboot_required_file.stat.exists
 
@@ -81,7 +74,7 @@
       when: reboot_required_file.stat.exists
 
     - name: Wait for node to start posting heartbeats
-      ansible.builtin.shell: $([[ {{time['ansible_date_time.iso8601']}} < $(kubectl get node {{hostname.stdout}} -o jsonpath='{.status.conditions[?(@.type=="Ready")].lastHeartbeatTime}' --kubeconfig /etc/kubernetes/admin.conf) ]])
+      ansible.builtin.shell: $([[ {{time['ansible_date_time.iso8601']}} < $(kubectl get node {{ inventory_hostname }} -o jsonpath='{.status.conditions[?(@.type=="Ready")].lastHeartbeatTime}' --kubeconfig /etc/kubernetes/admin.conf) ]])
       delegate_to: "{{groups['kube_control_plane'][0]}}"
       args:
         executable: /bin/bash
@@ -92,7 +85,7 @@
       when: reboot_required_file.stat.exists
 
     - name: Wait for node to be ready
-      ansible.builtin.shell: $([[ $(kubectl get node {{hostname.stdout}} -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' --kubeconfig /etc/kubernetes/admin.conf) == "True" ]])
+      ansible.builtin.shell: $([[ $(kubectl get node {{ inventory_hostname }} -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' --kubeconfig /etc/kubernetes/admin.conf) == "True" ]])
       delegate_to: "{{groups['kube_control_plane'][0]}}"
       args:
         executable: /bin/bash
@@ -103,6 +96,6 @@
       when: reboot_required_file.stat.exists
 
     - name: uncordon node
-      command: kubectl uncordon {{hostname.stdout}} --kubeconfig /etc/kubernetes/admin.conf
+      command: kubectl uncordon {{ inventory_hostname }} --kubeconfig /etc/kubernetes/admin.conf
       delegate_to: "{{groups['kube_control_plane'][0]}}"
       when: reboot_required_file.stat.exists


### PR DESCRIPTION
**What this PR does / why we need it**:
Changed reboot script to use the hostnames specified in the inventory file instead of the actual hostnames of the machines. This allows for the `override_system_hostname: false` setting to be used.

**Which issue this PR fixes**: fixes #261

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [x] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
