### PR TITLE
config: Fixed cloud provider

### DIFF
--- a/config/gcp/group_vars/all/ck8s-gcp.yaml
+++ b/config/gcp/group_vars/all/ck8s-gcp.yaml
@@ -1,4 +1,4 @@
-cloud_provider: gcp
+cloud_provider: gce
 gcp_pd_csi_enabled: true
 gcp_pd_csi_sa_cred_file: "set-me"
 gcp_pd_csi_controller_replicas: 1


### PR DESCRIPTION
In Kubespray the 'cloud_provider' var must be set either to 'gce' for Google Cloud

**What this PR does / why we need it**:

When deploying Compliant Kubernetes in Google Cloud, the cloud_provider variable needs to be defined as gce. Not gcp

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

I haven't created an issue. Should I?

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [ ] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
