### PR TITLE
rook-ceph: Add PSA labels and disable PSP

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,6 +1,8 @@
 ### Changed
 
 - Updated the Kubernetes audit log policy file
+- Added PSA labels for rook-ceph
+- Disabled Kubernetes PSPs for rook-ceph
 
 ### Fixed
 - Reboot scripts uses inventory hostnames instead of machine hostnames

--- a/rook/deploy-rook.sh
+++ b/rook/deploy-rook.sh
@@ -14,6 +14,9 @@ chart_version="v1.10.5"
 # Install rook operator
 kubectl create namespace "${namespace}" --dry-run -o yaml | kubectl apply -f -
 kubectl label namespace "${namespace}" owner=operator --overwrite
+kubectl label namespace "${namespace}" pod-security.kubernetes.io/audit=privileged
+kubectl label namespace "${namespace}" pod-security.kubernetes.io/enforce=privileged
+kubectl label namespace "${namespace}" pod-security.kubernetes.io/warn=privileged
 helm upgrade --install --namespace "${namespace}" "${release_name}" "${chart}" \
   --version "${chart_version}" --values "${here}/operator-values.yaml" --wait
 

--- a/rook/operator-values.yaml
+++ b/rook/operator-values.yaml
@@ -1,5 +1,6 @@
 # For a full list of values see
 # https://github.com/rook/rook/blob/v1.10.5/deploy/charts/rook-ceph/values.yaml
+pspEnable: false
 csi:
   enableCephfsDriver: false
   #provisionerTolerations:


### PR DESCRIPTION
**What this PR does / why we need it**:
 Add PSA labels and disable Kubernetes PSPs for rook-ceph
**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: Part of fix for [#1451](https://github.com/elastisys/compliantkubernetes-apps/issues/1451)

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [ ] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
