### PR TITLE
docs: exoscale terraform v0.48

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,0 +1,7 @@
+### Release notes
+
+- Exoscale terraform provider upgraded to v0.48.0
+
+### Added
+
+- Exoscale terraform provider upgraded to v0.48.0

--- a/migration/v2.21.0-ck8sx-v2.22.0-ck8sx/migrate-exoscale.sh
+++ b/migration/v2.21.0-ck8sx-v2.22.0-ck8sx/migrate-exoscale.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+
+set -eu
+
+: "${CK8S_CONFIG_PATH:?"CK8S_CONFIG_PATH is unset"}"
+
+if [[ "$1" =~ (sc|wc) ]]; then
+    cp "$CK8S_CONFIG_PATH/$1-config/terraform.tfstate" "$CK8S_CONFIG_PATH/$1-config/terraform-temp.tfstate"
+    terraformState="$CK8S_CONFIG_PATH/$1-config/terraform-temp.tfstate"
+    clusterVars="$CK8S_CONFIG_PATH/$1-config/cluster.tfvars"
+    export TF_VAR_inventory_file="$CK8S_CONFIG_PATH/$1-config/inventory-temp.ini"
+else
+    echo "usage: $0 <sc|wc>"
+    exit 1
+fi
+
+fetch_attributes() {
+    yq4 -oj '[.[].attributes]'
+}
+
+fetch_instances() {
+    yq4 -oj '[.[].instances[]]'
+}
+
+fetch_id() {
+    yq4 '.[].id'
+}
+
+fetch_index_key () {
+    yq4 ".[] | select(.attributes.id == \"${1}\") | .index_key"
+}
+
+fetch_master_instances() {
+    yq4 -oj '[.resources[] | select(.name == "master_nodes").instances[]]' "$1"
+}
+
+import_master_instances() {
+    node_id=$1
+    node_name=$2
+    zone=$3
+    # shellcheck disable=SC2086
+    terraform import -var-file "${clusterVars}" \
+        -state "${terraformState}" \
+        -config "${MODULE_PATH_TERRAFORM}" \
+        module.kubernetes.exoscale_compute_instance.master[\"${node_name}\"] ${node_id}@${zone}
+}
+
+fetch_worker_instances() {
+    yq4 -oj '[.resources[] | select(.name == "worker_nodes").instances[]]' "$1"
+}
+
+import_worker_instances() {
+    node_id=$1
+    node_name=$2
+    zone=$3
+    # shellcheck disable=SC2086
+    terraform import -var-file "${clusterVars}" \
+        -state "${terraformState}" \
+        -config "${MODULE_PATH_TERRAFORM}" \
+        module.kubernetes.exoscale_compute_instance.worker[\"${node_name}\"] ${node_id}@${zone}
+}
+
+fetch_private_network() {
+    yq4 -oj '[.resources[] | select(.name == "private_network")]' "$1"
+}
+
+fetch_exoscale_ipaddress(){
+    yq4 -oj "[.resources[] | select(.type == \"exoscale_ipaddress\" and (.name == \"$2\"))]" "$1"
+}
+
+import_private_network() {
+    network_id=$1
+    zone=$2
+    # shellcheck disable=SC2086
+    terraform import -var-file "${clusterVars}" \
+        -state "${terraformState}" \
+        -config "${MODULE_PATH_TERRAFORM}" \
+        module.kubernetes.exoscale_private_network.private_network ${network_id}@${zone}
+}
+
+import_elastic_ip(){
+    elastic_ip_id=$1
+    elastic_ip_name=$2
+    zone=$3
+    # shellcheck disable=SC2086
+    terraform import -var-file "${clusterVars}" \
+        -state "${terraformState}" \
+        -config "${MODULE_PATH_TERRAFORM}" \
+        module.kubernetes.exoscale_elastic_ip.${elastic_ip_name} ${elastic_ip_id}@${zone}
+}
+
+remove_old_instance() {
+    yq4 -ioj "del( .resources[] | select(.name == \"${2}\" and .type == \"${3}\") )" "$1"
+}
+
+pushd "$CK8S_CONFIG_PATH/$1-config"
+
+terraform init -upgrade -var-file "${clusterVars}" "${MODULE_PATH_TERRAFORM}"
+
+ingress_controller_lb_id=$(fetch_exoscale_ipaddress "${terraformState}" ingress_controller_lb | fetch_instances | fetch_attributes | fetch_id)
+control_plane_lb_id=$(fetch_exoscale_ipaddress "${terraformState}" control_plane_lb | fetch_instances | fetch_attributes | fetch_id)
+import_elastic_ip "${ingress_controller_lb_id}" ingress_controller_lb ch-gva-2
+import_elastic_ip "${control_plane_lb_id}" control_plane_lb ch-gva-2
+
+# shellcheck disable=SC2207
+master_nodes=( $(fetch_master_instances "${terraformState}" | fetch_attributes | fetch_id) )
+for node_id in "${master_nodes[@]}"; do
+    node_name=$(fetch_master_instances "${terraformState}" | fetch_index_key "${node_id}" )
+    import_master_instances "${node_id}" "${node_name}" ch-gva-2
+done
+
+# shellcheck disable=SC2207
+worker_nodes=( $(fetch_worker_instances "${terraformState}" | fetch_attributes | fetch_id) )
+for node_id in "${worker_nodes[@]}"; do
+    node_name=$(fetch_worker_instances "${terraformState}" | fetch_index_key "${node_id}" )
+    import_worker_instances "${node_id}" "${node_name}" ch-gva-2
+done
+
+network_id=$(fetch_private_network "${terraformState}" | fetch_instances | fetch_attributes | fetch_id)
+import_private_network "${network_id}" ch-gva-2
+
+remove_old_instance "${terraformState}" master exoscale_compute
+remove_old_instance "${terraformState}" worker exoscale_compute
+
+remove_old_instance "${terraformState}" master_nodes exoscale_compute
+remove_old_instance "${terraformState}" worker_nodes exoscale_compute
+
+remove_old_instance "${terraformState}" private_network exoscale_network
+
+remove_old_instance "${terraformState}" control_plane_lb exoscale_secondary_ipaddress
+remove_old_instance "${terraformState}" ingress_controller_lb exoscale_secondary_ipaddress
+
+remove_old_instance "${terraformState}" control_plane_lb exoscale_ipaddress
+remove_old_instance "${terraformState}" ingress_controller_lb exoscale_ipaddress
+
+remove_old_instance "${terraformState}" master_private_network_nic exoscale_nic
+remove_old_instance "${terraformState}" worker_private_network_nic exoscale_nic
+
+terraform plan -var-file "${clusterVars}" -state "${terraformState}" "${MODULE_PATH_TERRAFORM}"
+
+popd

--- a/migration/v2.21.0-ck8sx-v2.22.0-ck8sx/upgrade-cluster.md
+++ b/migration/v2.21.0-ck8sx-v2.22.0-ck8sx/upgrade-cluster.md
@@ -1,0 +1,74 @@
+# Upgrade v2.21.0-ck8sx to v2.22.0-ck8sx
+
+1. Checkout the new release: `git checkout v2.22.0-ck8sx`
+
+1. Switch to the correct remote: `git submodule sync`
+
+1. Update the kubespray submodule: `git submodule update --init --recursive`
+
+## Disruptive steps
+
+These steps will cause disruptions in the environment.
+
+1. Upgrade the cluster to a new kubernetes version:
+
+    ```bash
+    ./bin/ck8s-kubespray run-playbook sc upgrade-cluster.yml -b
+    ./bin/ck8s-kubespray run-playbook wc upgrade-cluster.yml -b
+    ```
+
+## Update terraform state for Exoscale environments
+
+1. Add the type of `family` each compute instance is part of in `cluster.tfvars`:
+
+    The nodes will most likely be part of `standard`.
+    You can check this by looking at the `type`, `family.size`, in the following output:
+
+    ```console
+    exo compute instance list
+    ┼──────────────────────────────────────┼──────────────────────────────────┼──────────┼──────────────────────┼─────────────────┼─────────┼
+    │                  ID                  │               NAME               │   ZONE   │         TYPE         │   IP ADDRESS    │  STATE  │
+    ┼──────────────────────────────────────┼──────────────────────────────────┼──────────┼──────────────────────┼─────────────────┼─────────┼
+    │ 05559c97-fe3d-465c-bf83-759beaad2beb │ worker-name                      │ ch-dk-2  │ standard.large       │ 0.0.0.0         │ running │
+    ```
+
+    ```diff
+    machines = {
+    "control-plane-1" : {
+        "node_type" : "master",
+        "size" : "Medium",
+   +   "family" : "standard",
+        "boot_disk" : {
+        "image_name" : "Linux Ubuntu 20.04 LTS 64-bit",
+        "root_partition_size" : 50,
+        "node_local_partition_size" : 0,
+        "ceph_partition_size" : 50
+        }
+    },
+    }
+    ```
+
+1. Run the migration script
+
+    ```console
+    migration/v2.21.0-ck8sx-v2.22.0-ck8sx/migrate-exoscale.sh sc
+    migration/v2.21.0-ck8sx-v2.22.0-ck8sx/migrate-exoscale.sh wc
+    ```
+
+1. The final plan should look like X
+
+    ```console
+    ...
+    ```
+
+1. Copy over the new state and delete the temp state
+
+    ```console
+    cp "$CK8S_CONFIG_PATH/sc-config/terraform-temp.tfstate" "$CK8S_CONFIG_PATH/sc-config/terraform.tfstate"
+    rm "$CK8S_CONFIG_PATH/sc-config/terraform-temp.tfstate"
+    rm "$CK8S_CONFIG_PATH/sc-config/terraform-temp.tfstate.backup"
+
+    cp "$CK8S_CONFIG_PATH/wc-config/terraform-temp.tfstate" "$CK8S_CONFIG_PATH/wc-config/terraform.tfstate"
+    rm "$CK8S_CONFIG_PATH/wc-config/terraform-temp.tfstate"
+    rm "$CK8S_CONFIG_PATH/wc-config/terraform-temp.tfstate.backup"
+    ```


### PR DESCRIPTION
**What this PR does / why we need it**:

The migration script for the new exoscale terraform. 
There are still som issues that needs to be addressed in exoscales terrafrom module.
I just added it to the next release, but it may change before this is done.

**Which issue this PR fixes**: fixes #270 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [ ] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
