### PR TITLE
rook-ceph: Update migration docs

### DIFF
--- a/migration/v2.20.0-ck8sx-v2.21.0-ck8s1/bypass-k8s-psp.sh
+++ b/migration/v2.20.0-ck8sx-v2.21.0-ck8s1/bypass-k8s-psp.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+
+apply() {
+  condition="$(kubectl -n kube-system get configmap kubeadm-config -o yaml | yq4 '.data.ClusterConfiguration | @yamld | .apiServer.extraArgs.enable-admission-plugins | split(",") | .[] | select(. == "PodSecurityPolicy")')"
+  if [[ "${condition}" != "PodSecurityPolicy" ]]; then
+    echo "- skipping - Kubernetes PodSecurityPolicy admission not enabled"
+    return
+  fi
+
+  echo "  - applying temporary bypass of vanilla Kubernetes PodSecurityPolicies"
+
+  if [[ -z "$(kubectl -n rook-ceph get rolebinding bypass-kubernetes-psp --ignore-not-found=true)" ]]; then
+    echo "  - applying rook-ceph bypass psp - "
+    kubectl -n rook-ceph create rolebinding bypass-kubernetes-psp --clusterrole psp:privileged --group "system:serviceaccounts:rook-ceph"
+  else
+    echo "  - skipping rook-ceph - already exists"
+  fi
+}
+
+delete() {
+  echo "- deleting temporary bypass of vanilla Kubernetes PodSecurityPolicies"
+
+  if [[ "$(kubectl -n rook-ceph get rolebinding bypass-kubernetes-psp --ignore-not-found=true)" ]]; then
+    echo "  - deleting rook-ceph bypass psp - "
+    kubectl -n rook-ceph delete rolebinding bypass-kubernetes-psp
+  else
+    echo "  - bypass-kubernets-psp was deleted"
+  fi
+}
+
+run() {
+  case "${1:-}" in
+  execute)
+    apply
+    ;;
+  clean)
+    delete
+    ;;
+  *)
+    echo "usage: \"${0}\" <execute|clean>"
+    ;;
+  esac
+}
+
+run "${@}"

--- a/migration/v2.20.0-ck8sx-v2.21.0-ck8s1/upgrade-cluster.md
+++ b/migration/v2.20.0-ck8sx-v2.21.0-ck8s1/upgrade-cluster.md
@@ -91,13 +91,33 @@ These steps will cause disruptions in the environment.
 
 1. **If the environment is running `rook-ceph`**
 
-    For both `sc` and `wc`, apply PSA labels to the namespace:
+    For both `sc` and `wc`:
 
-    ```bash
-    kubectl label namespace rook-ceph pod-security.kubernetes.io/audit=privileged
-    kubectl label namespace rook-ceph pod-security.kubernetes.io/enforce=privileged
-    kubectl label namespace rook-ceph pod-security.kubernetes.io/warn=privileged
-    ```
+    1. Apply PSA labels to the namespace:
+
+        ```bash
+        kubectl label namespace rook-ceph pod-security.kubernetes.io/audit=privileged
+        kubectl label namespace rook-ceph pod-security.kubernetes.io/enforce=privileged
+        kubectl label namespace rook-ceph pod-security.kubernetes.io/warn=privileged
+        ```
+
+    1. Apply bypass Kubernetes PSP:
+
+        ```bash
+        ./migration/v2.20.0-ck8sx-v2.21.0-ck8s1/bypass-k8s-psp.sh execute
+        ```
+
+    1. Upgrade the operator to remove PSP and associated RBAC
+
+        ```bash
+        namespace="rook-ceph"
+        release_name="rook-ceph"
+        chart="rook-release/rook-ceph"
+        chart_version="<set chart version>" # Can be fetched by running `helm list -n rook-ceph`
+        helm repo add rook-release https://charts.rook.io/release
+        helm diff upgrade --namespace "${namespace}" "${release_name}" "${chart}" --version "${chart_version}" --values "./rook/operator-values.yaml"
+        helm upgrade --namespace "${namespace}" "${release_name}" "${chart}" --version "${chart_version}" --values "./rook/operator-values.yaml" --wait
+        ```
 
 1. Upgrade the cluster to a new kubernetes version:
 
@@ -133,16 +153,10 @@ These steps will cause disruptions in the environment.
 
 1. **If the environment is running `rook-ceph`**
 
-    For both `sc` and `wc`, upgrade the operator to remove PSP and associated RBAC:
+    For both `sc` and `wc`, clean up bypass Kubernetes PSP:
 
     ```bash
-    namespace="rook-ceph"
-    release_name="rook-ceph"
-    chart="rook-release/rook-ceph"
-    chart_version="<set chart version>" # Can be fetched by running `helm list -n rook-ceph`
-    helm repo add rook-release https://charts.rook.io/release
-    helm diff upgrade --namespace "${namespace}" "${release_name}" "${chart}" --version "${chart_version}" --values "./rook/operator-values.yaml"
-    helm upgrade --namespace "${namespace}" "${release_name}" "${chart}" --version "${chart_version}" --values "./rook/operator-values.yaml" --wait
+    ./migration/v2.20.0-ck8sx-v2.21.0-ck8s1/bypass-k8s-psp.sh clean
     ```
 
 ## Postrequisite


### PR DESCRIPTION
**What this PR does / why we need it**:
An [issue](https://github.com/elastisys/compliantkubernetes-kubespray/issues/274) was found with the 2.20->2.21 migration for rook-ceph that I missed in the original PR for the PSP replacement.  

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #274 

**Special notes for reviewer**:
I was able to recreate the issue and test the proposed solution which worked perfectly. Another possible option would be to run kubespray to only disable PSP->Upgrade rook-ceph operator to remove PSP/RBAC->Continue with the actual cluster upgrade. This would take more work and time however in comparison to this solution. Could probably do some PSP bypass similar to apps instead as well.
Helm mapkubeapis docs:
https://helm.sh/docs/topics/kubernetes_apis/#updating-api-versions-of-a-release-manifest
https://github.com/helm/helm-mapkubeapis#background-to-the-issue

**Checklist:**

- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [ ] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
