### PR TITLE
bin: Add dependency check

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,6 +1,7 @@
 ### Added
 - Add additional pre-commit checks
 - Add new configuration file with compliantkubernetes-kubespray version
+- Dependency check to main bin scripts
 
 ### Changed
 

--- a/bin/ck8s-kubespray
+++ b/bin/ck8s-kubespray
@@ -36,6 +36,7 @@ fi
 
 # shellcheck source=bin/common.bash
 source "${here}/common.bash"
+check_tools
 
 case "${1}" in
     init)


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds the same dependency version check as in apps.
Only includes terraforms versioning.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: continuation on https://github.com/elastisys/compliantkubernetes-apps/issues/1478

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [x] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
