### PR TITLE
bin: fix version check to work from anywhere

### DIFF
--- a/bin/common.bash
+++ b/bin/common.bash
@@ -306,7 +306,9 @@ kubespray_version_check(){
 # Compares the checked out version and the config version of ck8s-kubespray.
 # Exits if they do not match.
 ck8s_kubespray_version_check(){
+    pushd "${root_path}" || exit
     version=$(git describe --exact-match --tags 2> /dev/null || git rev-parse HEAD)
+    popd || exit
     version_in_config=$(yq4 .ck8sKubesprayVersion "${config_path}/group_vars/all/ck8s-kubespray-general.yaml")
 
     if [[ -z "${version_in_config}" || "${version_in_config}" == "null" ]]; then


### PR DESCRIPTION
**What this PR does / why we need it**: If `bin/ck8s-kubespray <apply|run-playbook>` was executed from somewhere other than the `compliantkubernetes-kubespray` repository, the git version check would fail. This fixes that problem.

**Checklist:**

- [X] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [X] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
