### PR TITLE
fix: migration script typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Compliant Kubernetes Kubespray changelog
 <!-- BEGIN TOC -->
+- [v2.21.0-ck8s4](#v2210-ck8s4---2023-07-14)
 - [v2.22.1-ck8s1](#v2221-ck8s1---2023-07-12)
 - [v2.21.0-ck8s1](#v2210-ck8s1---2023-02-06)
 - [v2.20.0-ck8s1](#v2200-ck8s1---2022-10-10)
@@ -14,6 +15,13 @@
 <!-- END TOC -->
 
 -------------------------------------------------
+## v2.21.0-ck8s4 - 2023-07-14
+
+### Fixed
+
+- missing `s` from `containerd_enable_unprivileged_ports`
+
+-------------------------------------------------
 ## v2.22.1-ck8s1 - 2023-07-12
 
 ### Release notes
@@ -21,6 +29,7 @@
 - This version upgrades Kubernetes to `v1.26`
 
 ### Added
+
 - Add additional pre-commit checks
 - Add new configuration file with compliantkubernetes-kubespray version
 - Dependency check to main bin scripts
@@ -33,6 +42,7 @@
 - Upgraded kubespray to v2.22.1
 
 ### Fixed
+
 - Reboot scripts uses inventory hostnames instead of machine hostnames
 
 -------------------------------------------------

--- a/migration/v2.21/prepare/15-set-unprivileged.sh
+++ b/migration/v2.21/prepare/15-set-unprivileged.sh
@@ -10,7 +10,7 @@ for CLUSTER in sc wc; do
   if ! yq_null "${CLUSTER}" k8s_cluster/ck8s-k8s-cluster .containerd_max_container_log_line_size; then
     if yq4 '.containerd_max_container_log_line_size | test("unprivileged")' "${CK8S_CONFIG_PATH}/${CLUSTER}-config/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml"; then
       log_info "- enable unprivileged ports and icmp in ${CLUSTER}"
-      yq_add "${CLUSTER}" k8s_cluster/ck8s-k8s-cluster .containerd_enable_unprivileged_port true
+      yq_add "${CLUSTER}" k8s_cluster/ck8s-k8s-cluster .containerd_enable_unprivileged_ports true
       yq_add "${CLUSTER}" k8s_cluster/ck8s-k8s-cluster .containerd_enable_unprivileged_icmp true
 
       log_info "- remove the old containerd_max_container_log_line_size from ${CLUSTER}"


### PR DESCRIPTION
**What this PR does / why we need it**: fix typo in the migration scripts