### PR TITLE
added config to enable local volume provisioner

### DIFF
--- a/config/common/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml
+++ b/config/common/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml
@@ -723,3 +723,12 @@ audit_policy_custom_rules: |-
   - level: RequestResponse
     omitStages:
       - "RequestReceived"
+
+local_volume_provisioner_enabled: false # Set this to true if needed.
+local_volume_provisioner_storage_classes: # Installation via kubespray has no support for affinity, so the daemonset would run on all nodes.
+  local-storage:
+    host_dir: /mnt/disks/
+    mount_dir: /mnt/disks/
+
+local_volume_provisioner_nodelabels: []
+local_volume_provisioner_tolerations: []

--- a/docs/local-volume-provisioner.md
+++ b/docs/local-volume-provisioner.md
@@ -1,0 +1,45 @@
+# Setting up local volume provisioner
+
+## Steps
+
+To setup local volume provisioner on a node, add the following snippet to your ck8s-k8s-openstack.yaml. See the [docs](https://github.com/kubernetes-sigs/kubespray/blob/master/docs/kubernetes-apps/local_volume_provisioner.md) for more info.
+
+```yaml
+local_volume_provisioner_enabled: false #set this to true
+local_volume_provisioner_storage_classes: #For each key in local_volume_provisioner_storage_classes a "storage class" with the same name is created.
+  local-storage:
+    host_dir: /mnt/disks
+    mount_dir: /mnt/disks
+```
+
+> [!NOTE]
+> You need to make the partitions on the node beforehand.
+
+To make the partition on a node add the the cloudinit script to your terraform values file and create a new node. This has been tested on openstack clouds.
+
+```yaml
+k8s_nodes = {
+  "worker-x" = {
+    "az"          = "nova"
+    "flavor"      = "xxxx" #2C-8GB b2.c2r8
+    "floating_ip" = "false"
+    "root_volume_size_in_gb" = "100" #add this for safespring and not for elastx
+    "cloudinit"   = {
+      "extra_partitions" = [{
+        "volume_path"     = "/dev/sda" #The root volume may differ between clouds
+        "partition_path"  = "/dev/sda2"
+        "partition_start" = "50GB"
+        "partition_end"   = "-1"
+        "mount_path"      = "/mnt/disks/node-local-storage"
+      }]
+    }
+  }
+}
+```
+
+Once you have the partitions made and the kubespray values ready, apply the manifest using
+
+```bash
+./bin/ck8s-kubespray apply sc -b --tags=local-volume-provisioner
+./bin/ck8s-kubespray apply wc -b --tags=local-volume-provisioner
+```


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #238 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [x] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
