### PR TITLE
rook: zap and values fixes

### DIFF
--- a/rook/scripts/zap-disk
+++ b/rook/scripts/zap-disk
@@ -26,7 +26,3 @@ sudo rm -rf /dev/mapper/ceph--*
 sudo partprobe $DISK
 
 sudo rm -rf /var/lib/rook/
-
-# Ensure that everything is wiped
-lsblk
-ls /var/lib/rook

--- a/rook/scripts/zap-disk.sh
+++ b/rook/scripts/zap-disk.sh
@@ -20,10 +20,10 @@ fi
 if [[ "$#" -eq 1 ]]; then
     echo -n "Enter disk to wipe (Continue for default: sdb):"
     read -r disk
-    if [[ ${reply} -eq "" ]]; then
+    if [ -z "${disk}" ]; then
         DISK=sdb
     else
-        DISK=${disk}
+        DISK="${disk}"
     fi
     echo ""
 else

--- a/rook/template/values.yaml
+++ b/rook/template/values.yaml
@@ -65,9 +65,8 @@ commons:
       #             - rook-ceph
       # tolerations:
       #   - key: elastisys.io/node-type
-      #     operator: In
-      #     values:
-      #       - rook-ceph
+      #     operator: Equal
+      #     value: rook-ceph
       #     effect: NoSchedule
       ## these can be overridden for mgr, mon, osd below
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Found two issues when trying it out.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [x] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to app installers e.g. rook)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/change values under `config`)
bin: (changes to binaries or scripts)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
