### PR TITLE
bin: allow per cluster upgrade prepare

### DIFF
--- a/bin/ck8s-kubespray
+++ b/bin/ck8s-kubespray
@@ -24,7 +24,7 @@ usage() {
     echo "  prune-nerdctl                               removes unused container resources on all nodes" 1>&2
     echo "      args: <prefix> [<options>]" 1>&2
     echo "  upgrade                                     prepares config for upgrade" 1>&2
-    echo "      args: <version> prepare" 1>&2
+    echo "      args: <wc|sc|both> <version> prepare" 1>&2
     exit 1
 }
 
@@ -89,7 +89,7 @@ case "${1}" in
         "${here}/prune-nerdctl.bash" "${@}"
         ;;
     upgrade)
-        if [ $# -lt 3 ]; then
+        if [ $# -ne 4 ]; then
             usage
         fi
         shift 1

--- a/migration/template/prepare/00-template.sh
+++ b/migration/template/prepare/00-template.sh
@@ -22,3 +22,10 @@ source "${ROOT}/scripts/migration/lib.sh"
 
 # Note: 00-template.sh will be skipped by the upgrade command
 log_info "no operation: this is a template"
+
+if [[ "${CK8S_CLUSTER}" =~ ^(sc|both)$ ]]; then
+  log_info "operation on service cluster"
+fi
+if [[ "${CK8S_CLUSTER}" =~ ^(wc|both)$ ]]; then
+  log_info "operation on workload cluster"
+fi

--- a/migration/template/prepare/10-init.sh
+++ b/migration/template/prepare/10-init.sh
@@ -6,5 +6,9 @@ ROOT="$(readlink -f "${HERE}/../../../")"
 # shellcheck source=scripts/migration/lib.sh
 source "${ROOT}/scripts/migration/lib.sh"
 
-yq_add sc all/ck8s-kubespray-general .ck8sKubesprayVersion "\"$(git_version)\""
-yq_add wc all/ck8s-kubespray-general .ck8sKubesprayVersion "\"$(git_version)\""
+if [[ "${CK8S_CLUSTER}" =~ ^(sc|both)$ ]]; then
+  yq_add sc all/ck8s-kubespray-general .ck8sKubesprayVersion "\"$(git_version)\""
+fi
+if [[ "${CK8S_CLUSTER}" =~ ^(wc|both)$ ]]; then
+  yq_add wc all/ck8s-kubespray-general .ck8sKubesprayVersion "\"$(git_version)\""
+fi

--- a/migration/template/upgrade-cluster.md
+++ b/migration/template/upgrade-cluster.md
@@ -24,7 +24,13 @@
 
 1. Update the kubespray submodule: `git submodule update --init --recursive`
 
-1. Run `bin/ck8s-kubespray upgrade ${new_version} prepare` to update your config.
+1. Run `bin/ck8s-kubespray upgrade both ${new_version} prepare` to update your config.
+
+    > [!NOTE]
+    > It is possible to update `wc` and `sc` config separately by replacing `both` when running the `upgrade` command, e.g. the following will only update config for the workload cluster:
+    > ```bash
+    > bin/ck8s-kubespray upgrade wc ${new_version} prepare
+    > ```
 
 1. Download the required files on the nodes
 


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [x] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Critical security fixes should be marked with `kind/security`
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type

- [x] kind/admin-change  <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change    <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security      <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()       <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

### Platform Administrator notice

This PR changes the number of arguments required to run the `upgrade` command, as with this PR you need to specify the specific cluster, `sc`, `wc`, or `both` to apply to both clusters as the command did previously. The `ck8s-kubespray` usage has been updated to clarify this:
```bash
➜ ./bin/ck8s-kubespray         
COMMANDS:
  ...
  upgrade                                     prepares config for upgrade
      args: <wc|sc|both> <version> prepare
```

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
This PR allows for running the `upgrade prepare` command each cluster (`wc` and `sc`) separately, which is particularly useful for multi-workload cluster environments, or environments without workload clusters. Previously the upgrade command always applied for both `wc` and `sc`.

<!-- Add all issues that are fixed by this PR -->
- Fixes #315 

#### Additional information to reviewers

#### Screenshots

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - bin: changes to management binaries or scripts
    - config: changes to configuration
    - deploy: changes to deployment
    - docs: changes to documentation
    - tests: changes to tests
    - release: release related
    - rook: changes to rook deployment
  -->
- Change checks:
  - [ ] The change is transparent
  - [ ] The change is disruptive
  - [ ] The change requires no migration steps
  - [ ] The change requires migration steps
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [x] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [x] The logs do not show any errors after the change
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [x] The change does not cause any dropped packages in the `NetworkPolicy Dashboard`
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [x] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Falco checks:
  - [x] The change does not cause any alerts to be generated by Falco
