### PR TITLE
playbook: switch to ansible_host in authorized_key.yml

### DIFF
--- a/playbooks/authorized_key.yml
+++ b/playbooks/authorized_key.yml
@@ -8,7 +8,7 @@
     ssh_known_hosts: "{{ groups['all'] }}"
   tasks:
   - name: For each host, scan for its ssh public key
-    shell: "ssh-keyscan -t rsa {{ hostvars[item].ansible_ssh_host }} 2>/dev/null"
+    shell: "ssh-keyscan -t rsa {{ hostvars[item].ansible_host }} 2>/dev/null"
     with_items: "{{ ssh_known_hosts }}"
     register: ssh_known_host_results
     retries: 10
@@ -19,7 +19,7 @@
 
   - name: Remove the public key in the '{{ ssh_known_hosts_file }}'
     known_hosts:
-      name: "{{ hostvars[item.item].ansible_ssh_host }}"
+      name: "{{ hostvars[item.item].ansible_host }}"
       state: "absent"
       path: "{{ ssh_known_hosts_file }}"
     with_items: "{{ ssh_known_host_results.results }}"
@@ -28,7 +28,7 @@
 
   - name: Add/update the public key in the '{{ ssh_known_hosts_file }}'
     known_hosts:
-      name: "{{ hostvars[item.item].ansible_ssh_host }}"
+      name: "{{ hostvars[item.item].ansible_host }}"
       key: "{{ item.stdout }}"
       state: "present"
       path: "{{ ssh_known_hosts_file }}"

--- a/playbooks/reboot_nodes.yml
+++ b/playbooks/reboot_nodes.yml
@@ -37,11 +37,6 @@
       ignore_errors: true
       when: reboot_required_file.stat.exists
 
-    # Either ansible_host or ansible_ssh_host should be set to the target IP,
-    # but the other is probably set to localhost when running a local_action.
-    # So we need to pick the correct one.
-    # If both are set then a redundant wait is run.
-
     - name: Waiting for the machine to come back (ansible_host)
       local_action: wait_for host={{ ansible_host }} state=started port=22 delay=30 timeout=600
       become: no
@@ -50,12 +45,12 @@
       - ansible_host != "localhost"
       - reboot_required_file.stat.exists
 
-    - name: Waiting for the machine to come back (ansible_ssh_host)
-      local_action: wait_for host={{ ansible_ssh_host }} state=started port=22 delay=30 timeout=600
+    - name: Waiting for the machine to come back (ansible_host)
+      local_action: wait_for host={{ ansible_host }} state=started port=22 delay=30 timeout=600
       become: no
       register: machine_up
       when:
-      - ansible_ssh_host != "localhost"
+      - ansible_host != "localhost"
       - reboot_required_file.stat.exists
 
     - name: wait for kubectl access


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [x] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Critical security fixes should be marked with `kind/security`
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type

- [ ] kind/admin-change  <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change    <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security      <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()       <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
When running `apply-ssh` on `v2.24.0-ck8s1` on openstack environments it would fail with

```
TASK [For each host, scan for its ssh public key] ****************************************************************************************************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'ansible.vars.hostvars.HostVarsVars object' has no attribute 'ansible_ssh_host'. 'ansible.vars.hostvars.HostVarsVars object' has no attribute 'ansible_ssh_host'\n\nThe error appears to be in '/home/user/compliantkubernetes-kubespray/playbooks/authorized_key.yml': line 10, column 5, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n  tasks:\n  - name: For each host, scan for its ssh public key\n    ^ here\n"}
```

#### Additional information to reviewers

#### Screenshots

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - bin: changes to management binaries or scripts
    - config: changes to configuration
    - deploy: changes to deployment
    - docs: changes to documentation
    - tests: changes to tests
    - release: release related
    - rook: changes to rook deployment
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [x] The change requires no migration steps
  - [ ] The change requires migration steps
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packages in the `NetworkPolicy Dashboard`
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
