### PR TITLE
rook: Add ability to set RBD image features

### DIFF
--- a/rook/helmfile.d/values/cluster.yaml.gotmpl
+++ b/rook/helmfile.d/values/cluster.yaml.gotmpl
@@ -98,7 +98,7 @@ cephBlockPools:
         csi.storage.k8s.io/node-stage-secret-namespace: {{ $.Release.Namespace }}
         csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner
         csi.storage.k8s.io/provisioner-secret-namespace: {{ $.Release.Namespace }}
-        imageFeatures: layering
+        imageFeatures: {{ . | get "parameters.imageFeatures" "layering" }}
         imageFormat: "2"
     {{- end }}
 

--- a/rook/template/values.yaml
+++ b/rook/template/values.yaml
@@ -39,6 +39,11 @@ commons:
       name: rook-ceph-block
       # default: true
 
+      ## If the storage nodes use kernel 5.4 or newer, set imageFeatures to
+      ## "layering,fast-diff,object-map,deep-flatten,exclusive-lock"
+      # parameters:
+      #  imageFeatures: layering
+
       # allowVolumeExpansion: true
       # volumeBindingMode: Immediate
       # reclaimPolicy: Delete


### PR DESCRIPTION
### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [x] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

- [ ] kind/admin-change  <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change    <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security      <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()       <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
With Linux kernel 5.4 (which shipped, for example, with Ubuntu 20.04 LTS) several new Ceph RBD image features was implemented. The rook-ceph defaults, however, does not reflect this fact, and the existing default ("layering") is recommended only for kernels prior to 5.4. Adding the ability to set "imageFeatures" defaults when deploying rook-ceph aims to mitigate this.

From rook-ceph's documentation:
"Rook's default RBD configuration specifies only the layering feature, for broad compatibility with older kernels. If your Kubernetes nodes run a 5.4 or later kernel, additional feature flags can be enabled in the storage class. The fast-diff and object-map features are especially useful."

This change will not, however, change existing default behavior.

#### Additional information to reviewers

Changing parameters to an already existing storage storageclass is not allowed.

#### Screenshots

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - bin: changes to management binaries or scripts
    - config: changes to configuration
    - deploy: changes to deployment
    - docs: changes to documentation
    - tests: changes to tests
    - release: release related
    - rook: changes to rook deployment
  -->
- Change checks:
  - [ ] The change is transparent
  - [ ] The change is disruptive
  - [ ] The change requires no migration steps
  - [ ] The change requires migration steps
- Metrics checks:
  - [x] The metrics are still exposed and present in Grafana after the change
  - [x] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [x] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [x] The logs do not show any errors after the change
- Network Policy checks:
  - [x] Any changed pod is covered by Network Policies
  - [x] The change does not cause any dropped packages in the `NetworkPolicy Dashboard`
- Pod Security Policy checks:
  - [x] Any changed pod is covered by Pod Security Admission
  - [ x Any changed pod is covered by Gatekeeper Pod Security Policies
  - [x] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Falco checks:
  - [x] The change does not cause any alerts to be generated by Falco
