### PR TITLE
Port 2.24.1 ck8s2

### DIFF
--- a/changelog/2.24.1.md
+++ b/changelog/2.24.1.md
@@ -1,0 +1,32 @@
+# v2.24.1-ck8s1
+
+Released 2024-03-26
+
+## Changes by kind
+
+### Feature(s)
+
+- [#357](https://github.com/elastisys/compliantkubernetes-kubespray/pull/357) - rook: Add ability to set RBD image features @TorLdre
+
+### Improvement(s)
+
+- [#301](https://github.com/elastisys/compliantkubernetes-kubespray/pull/301) - bin: Playbooks for cis benchmark patching @robinelastisys
+- [#359](https://github.com/elastisys/compliantkubernetes-kubespray/pull/359) - Update kubespray submodule to v2.24.1 @Pavan-Gunda
+
+### Other(s)
+
+- [#349](https://github.com/elastisys/compliantkubernetes-kubespray/pull/349) - other: Port 2.24.0 ck8s1 @anders-elastisys @davidumea
+- [#351](https://github.com/elastisys/compliantkubernetes-kubespray/pull/351) - documentation: docs: Update issue templates and release resources @aarnq
+- [#355](https://github.com/elastisys/compliantkubernetes-kubespray/pull/355) - bug: playbook: switch to ansible_host in authorized_key.yml @davidumea
+- [#356](https://github.com/elastisys/compliantkubernetes-kubespray/pull/356) - bug: config: add extra tolerations for coredns @davidumea
+- [0c2d0](https://github.com/elastisys/compliantkubernetes-kubespray/commit/0c2d0e2fa34591b6856664ac570d16935790e0ef) - rook: Fixes to templates and helpers for migration
+
+## v2.24.1-ck8s2
+
+Released 2024-06-26
+
+## Changes by kind
+
+### Other(s)
+
+- [fec0757](https://github.com/elastisys/compliantkubernetes-kubespray/commit/fec07578e69093705b0909952648d93504efa693) - Update kubespray submodule with private cloud lb and anti affinity changes for Upcloud

--- a/changelog/2.24.1.md
+++ b/changelog/2.24.1.md
@@ -29,4 +29,4 @@ Released 2024-06-26
 
 ### Other(s)
 
-- [fec0757](https://github.com/elastisys/compliantkubernetes-kubespray/commit/fec07578e69093705b0909952648d93504efa693) - Update kubespray submodule with private cloud lb and anti affinity changes for Upcloud
+- [fec0757](https://github.com/elastisys/compliantkubernetes-kubespray/commit/fec07578e69093705b0909952648d93504efa693) - Update Kubespray submodule with private cloud lb and anti affinity changes for Upcloud


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [x] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change   <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security     <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()      <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
Patch release-2.24.1-ck8s2 to update Kubespray submodule with private cloud lb and anti affinity changes for Upcloud

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
  - all: changes to multiple areas
  - bin: changes to management binaries or scripts
  - config: changes to configuration
  - deploy: changes to deployment
  - docs: changes to documentation
  - release: release related
  - rook: changes to rook deployment
  - scripts: changes to other scripts
  - tests: changes to tests
  -->
- Change checks:
  - [ ] The change is transparent
  - [ ] The change is disruptive
  - [ ] The change requires no migration steps
  - [ ] The change requires migration steps
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packets in the `NetworkPolicy Dashboard`
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
  - [ ] The bug fix is covered by regression tests
