### PR TITLE
Only run lb legacy network migration script on upcloud environments

### DIFF
--- a/migration/v2.25/prepare/20-add-lb-legacy-network.sh
+++ b/migration/v2.25/prepare/20-add-lb-legacy-network.sh
@@ -1,14 +1,28 @@
 #!/usr/bin/env bash
 
+HERE="$(dirname "$(readlink -f "${0}")")"
+ROOT="$(readlink -f "${HERE}/../../../")"
+
+# shellcheck source=scripts/migration/lib.sh
+source "${ROOT}/scripts/migration/lib.sh"
+
 if [[ "${CK8S_CLUSTER}" =~ ^(sc|both)$ ]]; then
-  tfvars_file="${CK8S_CONFIG_PATH}/sc-config/cluster.tfvars"
-  if ! grep -P "^loadbalancer_legacy_network" "${tfvars_file}" >/dev/null; then
-    echo "loadbalancer_legacy_network = true" >> "${tfvars_file}"
+  if [[ -f "${CK8S_CONFIG_PATH}/sc-config/group_vars/k8s_cluster/ck8s-k8s-cluster-upcloud.yaml" ]]; then
+    tfvars_file="${CK8S_CONFIG_PATH}/sc-config/cluster.tfvars"
+    if ! grep -P "^loadbalancer_legacy_network" "${tfvars_file}" >/dev/null; then
+      echo "loadbalancer_legacy_network = true" >> "${tfvars_file}"
+    fi
+  else
+    log_info "Not an UpCloud environment, skipping sc"
   fi
 fi
 if [[ "${CK8S_CLUSTER}" =~ ^(wc|both)$ ]]; then
-  tfvars_file="${CK8S_CONFIG_PATH}/wc-config/cluster.tfvars"
-  if ! grep -P "^loadbalancer_legacy_network" "${tfvars_file}" >/dev/null; then
-    echo "loadbalancer_legacy_network = true" >> "${tfvars_file}"
+  if [[ -f "${CK8S_CONFIG_PATH}/wc-config/group_vars/k8s_cluster/ck8s-k8s-cluster-upcloud.yaml" ]]; then
+    tfvars_file="${CK8S_CONFIG_PATH}/wc-config/cluster.tfvars"
+    if ! grep -P "^loadbalancer_legacy_network" "${tfvars_file}" >/dev/null; then
+      echo "loadbalancer_legacy_network = true" >> "${tfvars_file}"
+    fi
+  else
+    log_info "Not an UpCloud environment, skipping wc"
   fi
 fi


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change   <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security     <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()      <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
I decided to check for the infra provider in a way that is only dependent on `compliantkubernetes-kubespray` rather than checking in the apps config, but let me know if you prefer another solution.

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
  - all: changes to multiple areas
  - bin: changes to management binaries or scripts
  - config: changes to configuration
  - deploy: changes to deployment
  - docs: changes to documentation
  - release: release related
  - rook: changes to rook deployment
  - scripts: changes to other scripts
  - tests: changes to tests
  -->
- Change checks:
  - [ ] The change is transparent
  - [ ] The change is disruptive
  - [ ] The change requires no migration steps
  - [ ] The change requires migration steps
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packets in the `NetworkPolicy Dashboard`
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
  - [ ] The bug fix is covered by regression tests
