### PR TITLE
Revise default config

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ ansible-playbook -e 'ansible_python_interpreter=/usr/bin/python3' --ask-become-p
     Arguments:
     - The init command accepts `wc` (_workload cluster_) or `sc` (_service cluster_) as first argument as to create separate folders for each cluster's configuration files.
     - `flavor` will determine some default values for a variety of config options.
-      Supported options are `default`, `gcp`, `aws`, `vsphere`, and `openstack`.
+      Supported options are `default`, `gcp`, `aws`, `vsphere`, `openstack` and `upcloud`.
     - `SOPS fingerprint` is the gpg fingerprint that will be used for SOPS encryption.
       You need to set this or the environment variable `CK8S_PGP_FP` the first time SOPS is used in your specified config path.
 

--- a/bin/init.bash
+++ b/bin/init.bash
@@ -27,6 +27,7 @@ if [ "${flavor}" != "default" ] &&
   [ "${flavor}" != "gcp" ] &&
   [ "${flavor}" != "openstack" ] &&
   [ "${flavor}" != "vsphere" ] &&
+  [ "${flavor}" != "upcloud" ] &&
   [ "${flavor}" != "aws" ]; then
   log_error "ERROR: Unsupported flavor: ${flavor}"
   exit 1

--- a/config/aws/group_vars/k8s_cluster/ck8s-k8s-cluster-aws.yaml
+++ b/config/aws/group_vars/k8s_cluster/ck8s-k8s-cluster-aws.yaml
@@ -1,1 +1,8 @@
 etcd_kubeadm_enabled: false
+
+ntp_filter_interface: false
+# Specify the interfaces
+# Only takes effect when ntp_filter_interface is true
+# ntp_interfaces:
+#   - ignore wildcard
+#   - listen <default interface>

--- a/config/common/group_vars/all/ck8s-kubespray-general.yaml
+++ b/config/common/group_vars/all/ck8s-kubespray-general.yaml
@@ -1,4 +1,4 @@
-ck8sKubesprayVersion: any
+ck8sKubesprayVersion: v2.27.0-ck8s1
 control_plane_label: node-role.kubernetes.io/control-plane
 group_label_primary: elastisys.io/node-type
 group_label_secondary: elastisys.io/ams-cluster-name

--- a/config/common/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml
+++ b/config/common/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml
@@ -1,6 +1,6 @@
 kube_oidc_auth: true
 kube_oidc_url: <IDP-URL|https://dex.BASE-DOMAIN>
-kube_oidc_client_id: <id-from-IDP|kubelogin>
+kube_oidc_client_id: kubelogin
 kube_oidc_client_secret: <secret-from-IDP|secret-from-dex>
 kube_oidc_username_claim: "email"
 kubeconfig_cluster_name: <CHANGE-ME-ENVIRONMENT-NAME-sc|CHANGE-ME-ENVIRONMENT-NAME-wc>
@@ -47,13 +47,14 @@ audit_log_maxbackups: 10
 podsecuritypolicy_enabled: false
 calico_felix_prometheusmetricsenabled: true
 
+resolvconf_mode: host_resolvconf
 kubelet_config_extra_args:
   imageGCHighThresholdPercent: 75
   imageGCLowThresholdPercent: 70
 
-calico_ipip_mode: 'Always'
-calico_vxlan_mode: 'Never'
-calico_network_backend: 'bird'
+calico_ipip_mode: "Always"
+calico_vxlan_mode: "Never"
+calico_network_backend: "bird"
 
 dns_extra_tolerations: [{effect: NoSchedule, operator: Exists}]
 coredns_additional_error_config: |
@@ -65,7 +66,12 @@ csi_snapshot_controller_enabled: true
 
 kube_scheduler_bind_address: 127.0.0.1
 kube_kubeadm_scheduler_extra_args:
-    profiling: false
+  profiling: false
+
+kubelet_shutdown_grace_period: 30s
+kubelet_shutdown_grace_period_critical_pods: 10s
+kubelet_image_gc_high_threshold: 75
+kubelet_image_gc_low_threshold: 70
 
 kube_scheduler_profiles:
   - schedulerName: default-scheduler
@@ -89,6 +95,7 @@ kubelet_secure_addresses: >-
   {%- endfor -%}
 
 ntp_enabled: true
+ntp_package: ntpsec
 ntp_manage_config: true
 ntp_servers:
   - "gbg1.ntp.netnod.se iburst"
@@ -104,6 +111,15 @@ ntp_servers:
   - "svl1.ntp.netnod.se iburst"
   - "svl2.ntp.netnod.se iburst"
 ntp_timezone: "Etc/UTC"
+
+local_volume_provisioner_nodelabels: []
+local_volume_provisioner_tolerations: []
+
+local_volume_provisioner_enabled: false # Set this to true if needed.
+local_volume_provisioner_storage_classes: # Installation via kubespray has no support for affinity, so the daemonset would run on all nodes.
+  local-storage:
+    host_dir: /mnt/disks/
+    mount_dir: /mnt/disks/
 
 audit_policy_custom_rules: |-
   # The following requests were manually identified as high-volume and low-risk,
@@ -744,19 +760,3 @@ audit_policy_custom_rules: |-
   - level: RequestResponse
     omitStages:
       - "RequestReceived"
-
-local_volume_provisioner_enabled: false # Set this to true if needed.
-local_volume_provisioner_storage_classes: # Installation via kubespray has no support for affinity, so the daemonset would run on all nodes.
-  local-storage:
-    host_dir: /mnt/disks/
-    mount_dir: /mnt/disks/
-
-local_volume_provisioner_nodelabels: []
-local_volume_provisioner_tolerations: []
-
-ntp_filter_interface: true
-# Specify the interfaces
-# Only takes effect when ntp_filter_interface is true
-ntp_interfaces:
-  - ignore wildcard
-  - listen ens3

--- a/config/openstack/group_vars/k8s_cluster/ck8s-k8s-cluster-openstack.yaml
+++ b/config/openstack/group_vars/k8s_cluster/ck8s-k8s-cluster-openstack.yaml
@@ -9,6 +9,7 @@ external_openstack_cloud_controller_extra_args:
   cluster-name: "set-me"
 
 cinder_csi_enabled: true
+cinder_topology: false
 persistent_volumes_enabled: true
 expand_persistent_volumes: true
 openstack_blockstorage_ignore_volume_az: true
@@ -25,7 +26,7 @@ storage_classes:
 # external_openstack_lbaas_floating_network_id: "Neutron floating network ID to create LBaaS VIP"
 # external_openstack_lbaas_floating_subnet_id: "Neutron subnet ID to get floating IP from"
 # external_openstack_lbaas_method: "ROUND_ROBIN"
-# external_openstack_lbaas_provider: "octavia"
+# external_openstack_lbaas_provider: "amphora"
 # external_openstack_lbaas_use_octavia: true
 # external_openstack_lbaas_create_monitor: true
 # external_openstack_lbaas_monitor_delay: "1m"
@@ -42,3 +43,15 @@ storage_classes:
 supplementary_addresses_in_ssl_keys: []
 
 kubeconfig_localhost_ansible_host: true
+
+external_openstack_enable_ingress_hostname: true
+
+## used to expose the openstack cloud controller metrics
+external_openstack_cloud_controller_bind_address: 0.0.0.0
+
+ntp_filter_interface: false
+# Specify the interfaces
+# Only takes effect when ntp_filter_interface is true
+# ntp_interfaces:
+#   - ignore wildcard
+#   - listen <default interface>

--- a/config/upcloud/group_vars/k8s_cluster/ck8s-k8s-cluster-upcloud.yaml
+++ b/config/upcloud/group_vars/k8s_cluster/ck8s-k8s-cluster-upcloud.yaml
@@ -18,3 +18,10 @@ storage_classes:
 supplementary_addresses_in_ssl_keys: [<loadbalancer-domain>, "kube.ops.CHANGE-ME-BASE-DOMAIN"]
 
 kubeconfig_localhost_ansible_host: true
+
+ntp_filter_interface: false
+# Specify the interfaces
+# Only takes effect when ntp_filter_interface is true
+# ntp_interfaces:
+#   - ignore wildcard
+#   - listen <default interface>

--- a/config/vsphere/group_vars/k8s_cluster/ck8s-k8s-cluster-vsphere.yaml
+++ b/config/vsphere/group_vars/k8s_cluster/ck8s-k8s-cluster-vsphere.yaml
@@ -14,3 +14,10 @@ external_vsphere_user: ""
 external_vsphere_datacenter: ""
 external_vsphere_kubernetes_cluster_id: ""
 vsphere_csi_enabled: true
+
+ntp_filter_interface: false
+# Specify the interfaces
+# Only takes effect when ntp_filter_interface is true
+# ntp_interfaces:
+#   - ignore wildcard
+#   - listen <default interface>


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->


### Release notes
Added support for initializing upcloud config

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
Updated default config
Added support for initializing upcloud config

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Part of https://github.com/elastisys/ck8s-issue-tracker/issues/352

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - bin: changes to management binaries
    - config: changes to configuration
    - deploy: changes to deployments
    - docs: changes to documentation
    - release: release related
    - rook: changes to rook deployment
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [x] The change is transparent
    - [ ] The change is disruptive
    - [x] The change requires no migration steps
    - [ ] The change requires migration steps
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
