### PR TITLE
Staging 2.26.0 ck8s4

### DIFF
--- a/changelog/2.26.0.md
+++ b/changelog/2.26.0.md
@@ -67,3 +67,17 @@ Released 2025-02-06
 
 - [e981da2](https://github.com/elastisys/kubespray/commit/e981da2b6595d4e7e73ef4d9e493f3c968df93a8) - reverted changes of commit e99226a
 - [a9a5ee3](https://github.com/elastisys/kubespray/commit/a9a5ee3c33b30d0356ca5b17e3df4dfae3227de7) - fix issue with floating-ip
+
+## v2.26.0-ck8s4
+
+Released 2025-03-04
+
+## Changes by kind
+
+### Feature(s)
+
+- [#421](https://github.com/elastisys/compliantkubernetes-kubespray/pull/421) - update submodule for upcloud ubuntu 24.04 support [@Ajarmar](https://github.com/Ajarmar)
+
+### Other(s)
+
+- [#420](https://github.com/elastisys/compliantkubernetes-kubespray/pull/420) - documentation: Update Ubuntu 24.04 migration guide to include instructions for UpCloud [@Ajarmar](https://github.com/Ajarmar)

--- a/migration/ubuntu/20.04-to-24.04-openstack.md
+++ b/migration/ubuntu/20.04-to-24.04-openstack.md
@@ -1,8 +1,8 @@
-# Migrate to Ubuntu 24.04 on Openstack
+# Migrate to Ubuntu 24.04 on Openstack/UpCloud
 
 > [!IMPORTANT]
-> This migration assumes that the environment is running on an Openstack environment.
-> This mainly applies to the terraform details, so you should be able to follow along with the Kubespray steps even if you're not running on an Openstack environment.
+> This migration assumes that the environment is running on an Openstack or UpCloud environment.
+> This mainly applies to the terraform details, so you should be able to follow along with the Kubespray steps even if you're not running on an Openstack/UpCloud environment.
 
 ## Prerequisites
 
@@ -28,13 +28,14 @@ These steps can be done without any disruption to the running cluster.
 
 - In `${CK8S_CONFIG_PATH}/<sc|wc>-config/cluster.tfvars` update the following:
 
-  - Change global `image_uuid` to the ID of Ubuntu 24.04
-  - Configure `image_id` for all existing nodes to the old image id
+  - Change global `image_uuid` (Openstack)/`template_name` (UpCloud) to the ID of Ubuntu 24.04
+  - Configure `image_id` (Openstack)/`template_name` (UpCloud) for all existing nodes to the old image id
 
 - Verify by running `terraform plan` and make sure there's no changes on any on the existing nodes
-- Add a new control plane node that doesn't specify `image_id` (To use the new image)
+- Add a new control plane node that doesn't specify `image_id`/`template_name` (To use the new image)
 - Verify by running `terraform plan` and make sure there's a new node added with the correct image
 - Add the rest of the new control plane nodes
+  - On UpCloud environments, also add the new nodes to `master-api` in `loadbalancers`
 - Run `terraform apply` to add all the new nodes
 - Backup the current state:
 
@@ -44,7 +45,7 @@ These steps can be done without any disruption to the running cluster.
   popd
   ```
 
-- Generate new inventory:
+- Generate new inventory (can be skipped for UpCloud environments):
 
   ```bash
   ./gen-inventory.sh <sc|wc>
@@ -216,6 +217,7 @@ These steps will cause disruptions in the cluster.
 - Add a new worker node that doesn't specify `image_id` (To use the new image)
 - Verify by running `terraform plan` and make sure there's a new node added with the correct image
 - Add the rest of the new worker nodes
+  - On UpCloud environments, also add the new nodes to `http` and `https` in `loadbalancers`
 - Run `terraform apply` to add all the new nodes
 - Add all the new worker nodes
 

--- a/migration/ubuntu/20.04-to-24.04-openstack.md
+++ b/migration/ubuntu/20.04-to-24.04-openstack.md
@@ -228,6 +228,16 @@ These steps will cause disruptions in the cluster.
   popd
   ```
 
+- Update the NetworkPolicies:
+
+  ```bash
+  pushd "${CK8S_APPS_REPOSITORY_PATH}"
+  ./bin/ck8s update-ips <sc|wc> apply
+
+  ./bin/ck8s ops helmfile <sc|wc> -l policy=netpol -i apply
+  popd
+  ```
+
 - Cordon then drain the old nodes and make sure everything starts up properly (Cordon all first to make sure the drain doesn't move things to any old machines)
 
 > [!CAUTION]
@@ -237,8 +247,8 @@ These steps will cause disruptions in the cluster.
   kubectl cordon <old-node1>
   kubectl cordon <old-node2>
   ...
-  kubectl drain <old-node1>
-  kubectl drain <old-node2>
+  kubectl drain <old-node1> --delete-emptydir-data --ignore-daemonsets
+  kubectl drain <old-node2> --delete-emptydir-data --ignore-daemonsets
   ...
   ```
 
@@ -251,6 +261,16 @@ These steps will cause disruptions in the cluster.
   ```
 
 - Remove old worker nodes using Terraform
+
+- Update the NetworkPolicies:
+
+  ```bash
+  pushd "${CK8S_APPS_REPOSITORY_PATH}"
+  ./bin/ck8s update-ips <sc|wc> apply
+
+  ./bin/ck8s ops helmfile <sc|wc> -l policy=netpol -i apply
+  popd
+  ```
 
 ## Cleanup
 


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [x] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
Staging for v2.26.0-ck8s4, adding support for migrating UpCloud environments to Ubuntu 24.04

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - bin: changes to management binaries
    - config: changes to configuration
    - deploy: changes to deployments
    - docs: changes to documentation
    - release: release related
    - rook: changes to rook deployment
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [x] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
