### PR TITLE
rook: add option to enable cephfs csi

### DIFF
--- a/rook/helmfile.d/values/networkpolicies.yaml.gotmpl
+++ b/rook/helmfile.d/values/networkpolicies.yaml.gotmpl
@@ -45,6 +45,16 @@ rules:
       - tcp: 6800
         end: 7300
 
+  {{- if .Values | get "csi.enableCephfsDriver" false }}
+  egress-rule-mds:
+    peers:
+      - podSelectorLabels:
+          app: rook-ceph-mds
+    ports:
+      - tcp: 6800
+        end: 7568
+  {{- end }}
+
   peers-rule-nodes:
     peers: {{- toYaml $netpol.nodePeers | nindent 6 }}
 
@@ -87,6 +97,9 @@ policies:
         - rule: egress-rule-mgr
         - rule: egress-rule-mon
         - rule: egress-rule-osd
+        {{- if .Values | get "csi.enableCephfsDriver" false }}
+        - rule: egress-rule-mds
+        {{- end }}
       ingress:
         - rule: ingress-rule-apiserver
           ports:
@@ -128,6 +141,9 @@ policies:
         - rule: egress-rule-apiserver
         - rule: egress-rule-mon
         - rule: egress-rule-osd
+        {{- if .Values | get "csi.enableCephfsDriver" false }}
+        - rule: egress-rule-mds
+        {{- end }}
       ingress:
         - name: ingress-rule-blackbox
           ports:
@@ -149,6 +165,12 @@ policies:
                 app: rook-ceph-osd
             - podSelectorLabels:
                 app: rook-ceph-crashcollector
+            {{- if .Values | get "csi.enableCephfsDriver" false }}
+            - podSelectorLabels:
+                app: csi-cephfsplugin-provisioner
+            - podSelectorLabels:
+                app: rook-ceph-mds
+            {{- end }}
           ports:
             - tcp: 6800
 
@@ -161,6 +183,9 @@ policies:
         - rule: egress-rule-mgr
         - rule: egress-rule-mon
         - rule: egress-rule-osd
+        {{- if .Values | get "csi.enableCephfsDriver" false }}
+        - rule: egress-rule-mds
+        {{- end }}
       ingress:
         - rule: peers-rule-nodes
           ports:
@@ -183,6 +208,12 @@ policies:
                 app: rook-ceph-crashcollector
             - podSelectorLabels:
                 app: rook-ceph-exporter
+            {{- if .Values | get "csi.enableCephfsDriver" false }}
+            - podSelectorLabels:
+                app: csi-cephfsplugin-provisioner
+            - podSelectorLabels:
+                app: rook-ceph-mds
+            {{- end }}
           ports:
             - tcp: 3300
             - tcp: 6789
@@ -195,6 +226,9 @@ policies:
         - rule: egress-rule-mgr
         - rule: egress-rule-mon
         - rule: egress-rule-osd
+        {{- if .Values | get "csi.enableCephfsDriver" false }}
+        - rule: egress-rule-mds
+        {{- end }}
         - rule: peers-rule-nodes
           ports:
             - tcp: 6800
@@ -215,6 +249,12 @@ policies:
                 app: rook-ceph-mgr
             - podSelectorLabels:
                 app: rook-ceph-osd
+            {{- if .Values | get "csi.enableCephfsDriver" false }}
+            - podSelectorLabels:
+                app: csi-cephfsplugin-provisioner
+            - podSelectorLabels:
+                app: rook-ceph-mds
+            {{- end }}
           ports:
             - tcp: 6800
               end: 7300
@@ -233,3 +273,56 @@ policies:
       egress:
         - rule: egress-rule-mgr
         - rule: egress-rule-mon
+        {{- if .Values | get "csi.enableCephfsDriver" false }}
+        - rule: egress-rule-mds
+        {{- end }}
+
+    {{- if .Values | get "csi.enableCephfsDriver" false }}
+    csi-cephfsplugin-provisioner:
+      podSelectorLabels:
+        app: csi-cephfsplugin-provisioner
+      egress:
+        - rule: egress-rule-apiserver
+        - rule: egress-rule-mgr
+        - rule: egress-rule-mon
+        - rule: egress-rule-mds
+        - rule: egress-rule-osd
+
+    ceph-file-controller-detect-version:
+      podSelectorLabels:
+        app: ceph-file-controller-detect-version
+      egress:
+        - rule: egress-rule-apiserver
+
+    mds:
+      podSelectorLabels:
+        app: rook-ceph-mds
+      egress:
+        - rule: egress-rule-apiserver
+        - rule: egress-rule-mgr
+        - rule: egress-rule-mon
+        - rule: egress-rule-osd
+      ingress:
+        - rule: peers-rule-nodes
+          ports:
+            - tcp: 6800
+              end: 7568
+        - peers:
+            - podSelectorLabels:
+                app: csi-cephfsplugin-provisioner
+            - podSelectorLabels:
+                app: rook-ceph-operator
+            - podSelectorLabels:
+                app.kubernetes.io/name: rook-ceph-toolbox
+            - podSelectorLabels:
+                app: rook-ceph-mon
+            - podSelectorLabels:
+                app: rook-ceph-osd
+            - podSelectorLabels:
+                app: rook-ceph-mgr
+            - podSelectorLabels:
+                app: rook-ceph-crashcollector
+          ports:
+            - tcp: 6800
+              end: 7568
+    {{- end }}

--- a/rook/helmfile.d/values/operator.yaml.gotmpl
+++ b/rook/helmfile.d/values/operator.yaml.gotmpl
@@ -16,7 +16,7 @@ tolerations: {{- toYaml . | nindent 2 }}
 {{- end }}
 
 csi:
-  enableCephfsDriver: false
+  enableCephfsDriver: {{ .Values | get "csi.enableCephfsDriver" false }}
 
   csiRBDProvisionerResource: |
     {{- range $name, $config := omit .Values.provisioner "tolerations" }}

--- a/rook/helmfile.d/values/podsecuritypolicies.yaml.gotmpl
+++ b/rook/helmfile.d/values/podsecuritypolicies.yaml.gotmpl
@@ -217,3 +217,97 @@ constraints:
           rule: RunAsAny
       mutation:
         dropAllCapabilities: false
+
+    {{ if .Values | get "csi.enableCephfsDriver" false }}
+    cephfs-ctrl-detect-version:
+      podSelectorLabels:
+        app: ceph-file-controller-detect-version
+      allow:
+        volumes:
+          - emptyDir
+          - projected
+      mutation:
+        runAsGroup: 2016
+        runAsUser: 2016
+        fsGroup: 2016
+
+    csi-cephfsplugin-provisioner:
+      podSelectorLabels:
+        app: csi-cephfsplugin-provisioner
+      allow:
+        volumes:
+          - configMap
+          - emptyDir
+          - hostPath
+          - projected
+        allowedHostPaths:
+          - pathPrefix: /dev
+          - pathPrefix: /lib/modules
+          - pathPrefix: /sys
+        runAsUser:
+          rule: RunAsAny
+        runAsGroup:
+          rule: RunAsAny
+        supplementalGroups:
+          rule: RunAsAny
+        fsGroup:
+          rule: RunAsAny
+      mutation:
+        dropAllCapabilities: false
+
+    csi-cephfsplugin:
+      podSelectorLabels:
+        app: csi-cephfsplugin
+      allow:
+        allowPrivilegeEscalation: true
+        hostNetworkPorts: true
+        hostNamespace: true
+        privileged: true
+        volumes:
+          - configMap
+          - emptyDir
+          - hostPath
+          - projected
+        allowedHostPaths:
+          - pathPrefix: /dev
+          - pathPrefix: /lib/modules
+          - pathPrefix: /run/mount
+          - pathPrefix: /run/udev
+          - pathPrefix: /sys
+          - pathPrefix: /var/lib/rook
+          - pathPrefix: /var/lib/kubelet/plugins_registry
+          - pathPrefix: /var/lib/kubelet/plugins
+          - pathPrefix: /var/lib/kubelet/pods
+        runAsUser:
+          rule: RunAsAny
+        runAsGroup:
+          rule: RunAsAny
+        supplementalGroups:
+          rule: RunAsAny
+        fsGroup:
+          rule: RunAsAny
+      mutation:
+        dropAllCapabilities: false
+
+    mds:
+      podSelectorLabels:
+        app: rook-ceph-mds
+      allow:
+        volumes:
+          - emptyDir
+          - hostPath
+          - projected
+          - secret
+        allowedHostPaths:
+          - pathPrefix: /var/lib/rook
+        runAsUser:
+          rule: RunAsAny
+        runAsGroup:
+          rule: RunAsAny
+        supplementalGroups:
+          rule: RunAsAny
+        fsGroup:
+          rule: RunAsAny
+      mutation:
+        dropAllCapabilities: false
+    {{ end }}

--- a/rook/template/values.yaml
+++ b/rook/template/values.yaml
@@ -203,3 +203,9 @@ clusters:
     networkPolicies:
       apiserverPeers: []
       nodePeers: []
+    csi:
+      # when true, the rook operator will install the necessary compononents
+      # for creating cephfs volumes in the workload cluster, which facilitate
+      # RWX mounts. This adds operational overhead in the form of
+      # metadata (mds), cephfs provisioner, and plugin pods in the ceph cluster.
+      enableCephfsDriver: false


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [x] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
These changes add the ability to enable the cephfs csi driver, which provides RWX volumes. CephFS is a posix compliant file system that can be mounted by multiple clients simultaneously, and is useful in some user workloads where shared storage is needed. Enabling cephfs comes at the expense of operational overhead. Metadata pods (Ceph MDS), csi-cephfsplugin and csi-cephfsplugin-provisioner pods are provisioned in the cluster, and while the rook operator handles this, more moving parts are introduced in the cluster.

CephFS is enabled by default in upstream rook ceph operator, but disabled in the compliantkubernetes-kubespray repo.

These changes will not change default behavior, and no configuration changes are needed in new or already installed clusters.

The configuration template suggests enabling this in the workload cluster. While one can enable it in the service cluster, there is really not a use case for it.

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->
This branch is up to date with elastisys/compliantkubernetes-kubespray:main.
- [ ] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - bin: changes to management binaries
    - config: changes to configuration
    - deploy: changes to deployments
    - docs: changes to documentation
    - release: release related
    - rook: changes to rook deployment
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [x] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [x] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [x] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [x] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [x] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [x] Any changed Pod is covered by Network Policies
    - [x] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
