### PR TITLE
Add dynamic inventory to label and taint nodes

### DIFF
--- a/bin/apply.bash
+++ b/bin/apply.bash
@@ -32,7 +32,7 @@ if [ -z "${CK8S_KUBESPRAY_NO_VENV+x}" ]; then
 fi
 
 log_info "Running kubespray"
-ansible-playbook -i "${config[inventory_file]}" cluster.yml -b "${@}"
+ansible-playbook -i "${config[inventory_file]}" -i "${here}/node-labels-and-taints-inventory.bash" cluster.yml -b "${@}"
 
 log_info "Kubespray done"
 

--- a/bin/ck8s-kubespray
+++ b/bin/ck8s-kubespray
@@ -30,6 +30,8 @@ usage() {
   echo "      args: <wc|sc>" 1>&2
   echo "  sync-groups-inventory                       sync groups static inventory" 1>&2
   echo "      args: <wc|sc>" 1>&2
+  echo "  node-labels-and-taints-inventory            dynamic inventory that configures node labels and taints" 1>&2
+  echo "      args: <wc|sc> [--list] [--host <hostname>]" 1>&2
   exit 1
 }
 
@@ -120,6 +122,13 @@ sync-groups-inventory)
   fi
   shift 2
   "${here}/sync-groups-inventory.bash" "${@}"
+  ;;
+node-labels-and-taints-inventory)
+  if [ $# -lt 2 ]; then
+    usage
+  fi
+  shift 2
+  "${here}/node-labels-and-taints-inventory.bash" "${@}"
   ;;
 *) usage ;;
 esac

--- a/bin/common.bash
+++ b/bin/common.bash
@@ -43,6 +43,8 @@ declare -A config
 config["inventory_file"]="${config_path}/inventory.ini"
 # shellcheck disable=SC2034
 config["groups_inventory_file"]="${config_path}/groups-inventory.ini"
+# shellcheck disable=SC2034
+config["node_labels_and_taints"]="${config_path}/node-labels-and-taints.yaml"
 
 declare -A KUBE
 KUBE[sc]="${CK8S_CONFIG_PATH}/.state/kube_config_sc.yaml"

--- a/bin/init.bash
+++ b/bin/init.bash
@@ -68,6 +68,13 @@ else
   log_info "Inventory already exists, leaving it as it is"
 fi
 
+# Copy node-labels-and-taints.yaml
+if [[ ! -f "${config[node_labels_and_taints]}" ]]; then
+  PREFIX=${prefix} envsubst >"${config[node_labels_and_taints]}" <"${config_defaults_path}/node-labels-and-taints.yaml"
+else
+  log_info "Node labels and taints configuration file already exists, leaving it as it is"
+fi
+
 log_info "Config initialized"
 
 log_info "Time to edit the following files:"

--- a/bin/node-labels-and-taints-inventory.bash
+++ b/bin/node-labels-and-taints-inventory.bash
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# This script will generate a dynamic inventory based on the
+# node-labels-and-taints.yaml config file. The dynamic inventory is then used
+# to apply node labels and taints when applying.
+
+set -eu -o pipefail
+
+here="$(dirname "$(readlink -f "$0")")"
+# shellcheck source=bin/common.bash
+source "${here}/common.bash"
+
+usage() {
+  echo "Usage: ${0} [--list] [--host <hostname>]" >&2
+  exit 1
+}
+
+[ "${#}" -ge 1 ] || usage
+
+if [ ! -f "${config["node_labels_and_taints"]}" ]; then
+  echo '{}'
+  exit
+fi
+
+declare -a identifiers
+
+readarray -t identifiers <<<"$(yq -r 'keys | .[]' "${config["node_labels_and_taints"]}")"
+
+inventory="$(ansible-inventory -i "${config[inventory_file]}" --list)"
+
+inventory_yaml() {
+  for identifier in "${identifiers[@]}"; do
+    echo "node-label-and-taints-${identifier}:"
+    echo "  hosts:"
+    echo "${inventory}" | yq --input-format json --output-format yaml '[.k8s_cluster.hosts[] | select(test("'"${identifier}"'"))]' | sed 's/^/    /'
+    echo "  vars:"
+    yq ".${identifier}" "${config["node_labels_and_taints"]}" | sed 's/^/    /'
+  done
+}
+
+case "${1}" in
+"--list")
+  inventory_yaml | yq -o json
+  ;;
+"--host")
+  echo '{}'
+  ;;
+*)
+  usage
+  ;;
+esac

--- a/config/node-labels-and-taints.yaml
+++ b/config/node-labels-and-taints.yaml
@@ -1,0 +1,6 @@
+control-plane:
+  node_labels:
+    elastisys.io/node-type: control-plane
+worker:
+  node_labels:
+    elastisys.io/node-type: worker

--- a/docs/node-labels-and-taints.md
+++ b/docs/node-labels-and-taints.md
@@ -1,0 +1,94 @@
+# Labeling and tainting nodes
+
+To add labels and taints to nodes modify the configuration file `node-labels-and-taints.yaml`.
+
+## Syntax
+
+This is the syntax of the configuration file.
+
+```yaml
+host_identifier:
+  node_labels:
+    key: value
+  node_taints:
+    - key=value:effect
+```
+
+The `host_identifier` will substring-match against hosts in the group `k8s_cluster` in the inventory.
+
+## Applying
+
+When running `ck8s-kubespray apply` the node labels and taints will be applied as part of the regular cluster deployment.
+
+To only apply node labels and taints you can run:
+
+```sh
+ck8s-kubespray apply <sc|wc> --tags node-label,node-taint
+```
+
+## Example
+
+This example shows how the node labels and taints configuration applies.
+
+inventory.ini:
+
+```ini
+[all]
+foo-sc-control-plane-1
+foo-sc-control-plane-2
+foo-sc-control-plane-3
+foo-sc-worker-1
+foo-sc-worker-2
+foo-sc-worker-3
+foo-sc-worker-4
+
+[kube_control_plane]
+foo-sc-control-plane-1
+foo-sc-control-plane-2
+foo-sc-control-plane-3
+
+[etcd]
+foo-sc-control-plane-1
+foo-sc-control-plane-2
+foo-sc-control-plane-3
+
+[kube_node]
+foo-sc-worker-1
+foo-sc-worker-2
+foo-sc-worker-3
+foo-sc-worker-4
+
+[k8s_cluster:children]
+kube_control_plane
+kube_node
+```
+
+node-labels-and-taints.yaml:
+
+```yaml
+control-plane:
+  node_labels:
+    role: control-plane
+  node_taints:
+    - control-plane:NoSchedule
+worker:
+  node_labels:
+    role: worker
+worker-4:
+  node_labels:
+    special: cargo
+  node_taints:
+    - special-cargo=true:NoSchedule
+```
+
+Result:
+
+```text
+foo-sc-control-plane-1 labels(role=control-plane) taints(control-plane:NoSchedule)
+foo-sc-control-plane-2 labels(role=control-plane) taints(control-plane:NoSchedule)
+foo-sc-control-plane-3 labels(role=control-plane) taints(control-plane:NoSchedule)
+foo-sc-worker-1 labels(role=worker) taints()
+foo-sc-worker-2 labels(role=worker) taints()
+foo-sc-worker-3 labels(role=worker) taints()
+foo-sc-worker-4 labels(role=worker, special=cargo) taints(special-cargo=true:NoSchedule)
+```


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [x] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [x] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

### Platform Administrator notice
Node labels and taints can now be applied using the configuration file `node-labels-and-taints.yaml`.

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

- Fixes https://github.com/elastisys/ck8s-issue-tracker/issues/429

This adds a way for platform administrators to label and taint nodes. See the documentation for further details.

#### Information to reviewers

Nothing should break even if the configuration file is missing but I'm curious how you think we should handle existing environments.

Adding a migration script that introduces the node-labels-and-taints.yaml file might be problematic since we don't really know which node labels and taints should be used.

Is the admin note enough?

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - bin: changes to management binaries
    - config: changes to configuration
    - deploy: changes to deployments
    - docs: changes to documentation
    - release: release related
    - rook: changes to rook deployment
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [ ] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
