### PR TITLE
fix(calico): remove pinned version

### DIFF
--- a/config/common/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml
+++ b/config/common/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml
@@ -56,8 +56,6 @@ calico_ipip_mode: "Always"
 calico_vxlan_mode: "Never"
 calico_network_backend: "bird"
 
-calico_version: v3.27.4
-
 dns_extra_tolerations: [{effect: NoSchedule, operator: Exists}]
 coredns_additional_error_config: |
   consolidate 5m ".* i/o timeout$" warning

--- a/migration/v2.28/README.md
+++ b/migration/v2.28/README.md
@@ -33,6 +33,9 @@
     > bin/ck8s-kubespray upgrade wc v2.28 prepare
     > ```
 
+    > [!IMPORTANT]
+    > This upgrade removes the pinned Calico version (`calico_version: v3.27.4`) from your configuration, allowing Kubespray to use its default version (v3.29.1). This change fixes compatibility issues with calico-accountant in Calico v3.29.x. Ensure your compliantkubernetes-apps version is v0.48+ before proceeding with this upgrade.
+
 1. Download the required files on the nodes
 
     ```bash

--- a/migration/v2.28/prepare/20-remove-calico-version-pin.sh
+++ b/migration/v2.28/prepare/20-remove-calico-version-pin.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+HERE="$(dirname "$(readlink -f "${0}")")"
+ROOT="$(readlink -f "${HERE}/../../../")"
+
+# shellcheck source=scripts/migration/lib.sh
+source "${ROOT}/scripts/migration/lib.sh"
+
+log_info "Removing calico_version pin to use Kubespray default (v3.29.x)"
+
+if [[ "${CK8S_CLUSTER}" =~ ^(sc|both)$ ]]; then
+  log_info "Removing calico_version from service cluster config"
+  yq4 -i 'del(.calico_version)' "${CK8S_CONFIG_PATH}/sc-config/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml"
+fi
+
+if [[ "${CK8S_CLUSTER}" =~ ^(wc|both)$ ]]; then
+  log_info "Removing calico_version from workload cluster config"
+  yq4 -i 'del(.calico_version)' "${CK8S_CONFIG_PATH}/wc-config/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml"
+fi
+
+log_info "Calico will now use the default version from Kubespray (v3.29.1)"
+log_info "This change requires compliantkubernetes-apps version v0.47+ that supports Calico v3.29.x"


### PR DESCRIPTION
### What kind of PR is this?

- [x] kind/bug           <!-- This PR fixes a bug -->

### What does this PR do / why do we need this PR?

Bumps `calico-accountant` from `0.1.6-ck8s2` to `0.1.6-ck8s3`.
This fixes an issue where, under Kubespray-based clusters, the
exporter could emit **duplicate metric samples with identical label sets** during
the same scrape interval.

This is linked to [this](https://github.com/elastisys/compliantkubernetes-apps/pull/2585) PR on apps

#### Checklist

- [x] Proper commit message prefix on all commits
- Change checks:
    - [x] The change is transparent
    - [ ] The change is disruptive
    - [x] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [x] The public documentation required no updates
- Metrics checks:
    - [x] The metrics are still exposed and present in Grafana after the change
    - [x] The metrics names didn't change
- Logs checks:
    - [x] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [x] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [x] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [x] The change does not cause any Pods to be blocked
- NetworkPolicy checks:
    - [x] Any changed Pod is covered by Network Policies
    - [x] The change does not cause any dropped packets
- Audit checks:
    - [x] The change does not cause any unnecessary Kubernetes audit events
- Falco checks:
    - [x] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [x] The bug fix is covered by regression tests
