### PR TITLE
Avoid overwriting GPU containerd config 

### DIFF
--- a/config/common/group_vars/all/ck8s-containerd.yaml
+++ b/config/common/group_vars/all/ck8s-containerd.yaml
@@ -11,3 +11,6 @@
 #       - host: https://registry-1.docker.io
 #         capabilities: ["pull", "resolve"]
 #         skip_verify: false
+
+containerd_extra_args: |
+  imports = ["/etc/containerd/*-config.toml"]


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
As mentioned in the issue. https://github.com/elastisys/compliantkubernetes-apps/issues/2500
It needs extra containerd runtime configs to GPU pods. The configuration is done by `nvidia-container-toolkit-daemonset` on the GPU nodes. The toolkit overwrites `/etc/containerd/config.yaml` file when it's started. 

However, if we run some upgrade task in kubespray,  the containerd task would overwirte the `/etc/containerd/config.yaml`  file back to the default, and GPU pods won't be able to be spawn on the node due to runtime error.

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes https://github.com/elastisys/compliantkubernetes-apps/issues/2500

#### Information to reviewers ( Important, please read before reviewing )

I have came up with several options to resolve this issue. I push one solution per commit, eventually we will just keep one of them. Please provide your opinion on which one you prefer, and provide your reviews on your preferred solution. 
- Option 1, 98fc59439099e0589aabbae112e4af98d438663d
   Same as suggested in the issue. It asks GPU toolkit to write the config to a separate file `/etc/containerd/nvidia-config.yaml` (https://github.com/elastisys/compliantkubernetes-apps/pull/2604). In kubespray, it imports the file to the default containerd config. I personally prefer this one, but as mentioned in the issue, the drawback is that it needs update in both kubespray and apps.
- Option 2, Restart nvidia toolkit pod.
  As nvidia-toolkit overwrites the containerd config file when it starts on a node, restart the pod would simply solve the problem. 
  -  Method 1, c556e80ffacf074aecbfd7c7972448cb431c18f3 
     I added a playbook to to find the toolkit pod and restarts. The tasks can be added to the contrainerd playbook, so we guarantee the toolkit pod would restart and rewrite the config file every time when there's changes in conatinerd.
  - Method 2, (not implemented yet as I prefer Option 1, also think it needs an arch decision to deploy it as it's a separate function )
    Add a file watcher deployment to the cluster, which can automatically restart the toolkit pod when it detects changes made in the file `/etc/containerd/config.yaml`. 

  Although the restating option seems more straight-forward as it requires changes in only one repo, it has some drawbacks. Currently we don't have any customized containerd configs, so allowing nvidia-toolkit to overwrite it does not matter. It will become a issue if we add some customized configs in the future.
 
#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - bin: changes to management binaries
    - config: changes to configuration
    - deploy: changes to deployments
    - docs: changes to documentation
    - release: release related
    - rook: changes to rook deployment
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [ ] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
