### PR TITLE
script: add a systemd job to kill old apt processes

### DIFF
--- a/playbooks/kill_stuck_apt.yml
+++ b/playbooks/kill_stuck_apt.yml
@@ -1,0 +1,75 @@
+- name: Install systemd timer to kill stuck apt processes
+  hosts: all
+  become: true
+
+  tasks:
+    - name: Copy kill_stuck_apt.sh to /usr/local/bin
+      copy:
+        dest: /usr/local/bin/kill_stuck_apt.sh
+        content: |
+          #!/bin/bash
+
+          PIDS=$(ps -eo pid,etime,comm | awk '
+            $3 ~ /^apt(-get|itude)?$/ {
+              pid = $1;
+              etime = $2;
+              split(etime, d, "-");
+
+              if (length(d) == 2) {
+                days = d[1];
+                timepart = d[2];
+              } else {
+                days = 0;
+                timepart = d[1];
+              }
+
+              split(timepart, t, ":");
+
+              if (length(t) == 3) {
+                hours = t[1];
+                minutes = t[2];
+                seconds = t[3];
+              } else if (length(t) == 2) {
+                hours = 0;
+                minutes = t[1];
+                seconds = t[2];
+              } else {
+                hours = 0;
+                minutes = 0;
+                seconds = t[1];
+              }
+
+              total_seconds = days*86400 + hours*3600 + minutes*60 + seconds;
+
+              if (total_seconds > 86400) {
+                print pid;
+              }
+            }
+          ')
+
+          for pid in $PIDS; do
+            echo "Killing stuck apt process PID=$pid"
+            kill -9 $pid
+          done
+        mode: '0755'
+
+    - name: Deploy systemd service unit
+      template:
+        src: templates/kill-stuck-apt.service.j2
+        dest: /etc/systemd/system/kill-stuck-apt.service
+        mode: '0644'
+
+    - name: Deploy systemd timer unit
+      template:
+        src: templates/kill-stuck-apt.timer.j2
+        dest: /etc/systemd/system/kill-stuck-apt.timer
+        mode: '0644'
+
+    - name: Reload systemd daemon
+      command: systemctl daemon-reload
+
+    - name: Enable and start systemd timer
+      systemd:
+        name: kill-stuck-apt.timer
+        enabled: true
+        state: started

--- a/playbooks/kill_stuck_apt.yml
+++ b/playbooks/kill_stuck_apt.yml
@@ -8,14 +8,14 @@
         dest: /usr/local/bin/kill_stuck_apt.sh
         content: |
           #!/bin/bash
-          
+
           # Find and kill apt-related processes that have been running for more than 24 hours (86400 seconds)
           PIDS=$(ps -eo pid,etimes,comm | awk '
             $3 ~ /^apt(-get|itude)?$/ && $2 > 86400 {
               print $1
             }
           ')
-          
+
           for pid in $PIDS; do
             echo "Killing stuck apt process PID=$pid"
             kill -9 "$pid"

--- a/playbooks/kill_stuck_apt.yml
+++ b/playbooks/kill_stuck_apt.yml
@@ -8,48 +8,17 @@
         dest: /usr/local/bin/kill_stuck_apt.sh
         content: |
           #!/bin/bash
-
-          PIDS=$(ps -eo pid,etime,comm | awk '
-            $3 ~ /^apt(-get|itude)?$/ {
-              pid = $1;
-              etime = $2;
-              split(etime, d, "-");
-
-              if (length(d) == 2) {
-                days = d[1];
-                timepart = d[2];
-              } else {
-                days = 0;
-                timepart = d[1];
-              }
-
-              split(timepart, t, ":");
-
-              if (length(t) == 3) {
-                hours = t[1];
-                minutes = t[2];
-                seconds = t[3];
-              } else if (length(t) == 2) {
-                hours = 0;
-                minutes = t[1];
-                seconds = t[2];
-              } else {
-                hours = 0;
-                minutes = 0;
-                seconds = t[1];
-              }
-
-              total_seconds = days*86400 + hours*3600 + minutes*60 + seconds;
-
-              if (total_seconds > 86400) {
-                print pid;
-              }
+          
+          # Find and kill apt-related processes that have been running for more than 24 hours (86400 seconds)
+          PIDS=$(ps -eo pid,etimes,comm | awk '
+            $3 ~ /^apt(-get|itude)?$/ && $2 > 86400 {
+              print $1
             }
           ')
-
+          
           for pid in $PIDS; do
             echo "Killing stuck apt process PID=$pid"
-            kill -9 $pid
+            kill -9 "$pid"
           done
         mode: '0755'
 

--- a/playbooks/templates/kill-stuck-apt.service.j2
+++ b/playbooks/templates/kill-stuck-apt.service.j2
@@ -1,0 +1,6 @@
+[Unit]
+Description=Kill stuck apt processes older than 1 day
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/kill_stuck_apt.sh

--- a/playbooks/templates/kill-stuck-apt.timer.j2
+++ b/playbooks/templates/kill-stuck-apt.timer.j2
@@ -1,0 +1,9 @@
+[Unit]
+Description=Run kill-stuck-apt script daily at 2:00 AM
+
+[Timer]
+OnCalendar=*-*-* 02:00:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
...

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - bin: changes to management binaries
    - config: changes to configuration
    - deploy: changes to deployments
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [ ] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
