### PR TITLE
Adding default values for fs.inotify params

### DIFF
--- a/config/common/group_vars/all/ck8s-sysctl.yaml
+++ b/config/common/group_vars/all/ck8s-sysctl.yaml
@@ -1,0 +1,3 @@
+additional_sysctl:
+  - { name: "fs.inotify.max_user_instances", value: 8192 }
+  - { name: "fs.inotify.max_user_watches", value: 524288 }

--- a/migration/v2.28/prepare/30-add-sysctl-file.sh
+++ b/migration/v2.28/prepare/30-add-sysctl-file.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+HERE="$(dirname "$(readlink -f "${0}")")"
+ROOT="$(readlink -f "${HERE}/../../../")"
+
+# shellcheck source=scripts/migration/lib.sh
+source "${ROOT}/scripts/migration/lib.sh"
+
+if [[ "${CK8S_CLUSTER}" == "both" ]]; then
+  clusters=("sc" "wc")
+else
+  clusters+=("${CK8S_CLUSTER}")
+fi
+
+src_file="${ROOT}/config/common/group_vars/all/ck8s-sysctl.yaml"
+
+if [[ ! -f "${src_file}" ]]; then
+  log_error "Source file not found: ${src_file}"
+  exit 1
+fi
+
+for cluster in "${clusters[@]}"; do
+    mapfile -t matches < <(grep -Rn "additional_sysctl" "${CK8S_CONFIG_PATH}/${cluster}-config/group_vars")
+
+    if (( ${#matches[@]} > 0 )); then
+        log_info "Existing settings found in ${CK8S_CONFIG_PATH}/${cluster}-config/group_vars, skipping"
+    else
+        log_info "Copying sysctl defaults for ${cluster}"
+        dst_file="${CK8S_CONFIG_PATH}/${cluster}-config/group_vars/all/ck8s-sysctl.yaml"
+        cp "${src_file}" "${dst_file}"
+    fi
+done
+


### PR DESCRIPTION

<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->

This PR increases the default values for these sysctl settings:
  - `fs.inotify.max_user_instances=8192`
  - `fs.inotify.max_user_watches=524288`

These particular values were chosen to harmonize with the CAPI defaults: https://github.com/elastisys/image-builder/blob/main/images/capi/ansible/roles/node/tasks/main.yml#L65-L66

The user has the ability to override these settings, either globally or on group level (assuming there is an inventory to support it).

Also including a migration script for it.

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes https://github.com/elastisys/ck8s-issue-tracker/issues/560

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - bin: changes to management binaries
    - config: changes to configuration
    - deploy: changes to deployments
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [ ] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
