### PR TITLE
feat: implement rollback

### DIFF
--- a/migration/calico-to-cilium/20-migrate-node.sh
+++ b/migration/calico-to-cilium/20-migrate-node.sh
@@ -17,6 +17,13 @@ if [[ -z "${NODE}" ]]; then
 fi
 NODE_HASH="$(echo -n "${NODE}" | md5sum | awk '{print $1}')"
 
+CALICO_TO_CILIUM=true
+EVICT_PODS_WITH_IP_PREFIX="${CALICO_IP_PREFIX}"
+if [[ "${2:-}" == "--rollback" ]]; then
+  CALICO_TO_CILIUM=false
+  EVICT_PODS_WITH_IP_PREFIX="${CILIUM_IP_PREFIX}"
+fi
+
 log_info "Starging migration for node $(yellow_text "${NODE}") with hash $(yellow_text "${NODE_HASH}")"
 
 deferred_cleanup() {
@@ -33,15 +40,17 @@ trap deferred_cleanup EXIT
 label_node "${NODE}" "cilium-default"
 label_node "${NODE}" "skip-taint"
 
-# Cycle the cilium pod of the node to trigger CNI re-configuration
-log_info "Cycling cilium pod on $(yellow_text "${NODE}")"
-kubectl -n kube-system delete pod --field-selector spec.nodeName="${NODE}" -l k8s-app=cilium
-kubectl -n kube-system rollout status daemonset/cilium --watch
+if ${CALICO_TO_CILIUM}; then
+  # Cycle the cilium pod of the node to trigger CNI re-configuration
+  log_info "Cycling cilium pod on $(yellow_text "${NODE}")"
+  kubectl -n kube-system delete pod --field-selector spec.nodeName="${NODE}" -l k8s-app=cilium
+  kubectl -n kube-system rollout status daemonset/cilium --watch
 
-# Check the node connectivity
-if ! check_node_connectivity "${NODE}" "${NODE_HASH}"; then
-  log_error "FATAL: could not confirm network connectivity for node ${NODE}"
-  exit 1
+  # Check the node connectivity
+  if ! check_node_connectivity "${NODE}" "${NODE_HASH}"; then
+    log_error "FATAL: could not confirm network connectivity for node ${NODE}"
+    exit 1
+  fi
 fi
 
 # Add a temporary taint to all OTHER nodes (prevents scheduling elsewhere)
@@ -50,4 +59,4 @@ taint_nodes "cilium-guard-${NODE_HASH}" "$(get_unlabeled_nodes "skip-taint")"
 
 # Evict node pods managed by Calico one by one, with retries, thus respecting PDBs
 # -> since we tainted every other node, they should be scheduling on the node we're processing
-get_node_pods_with_ip_prefix "${NODE}" "${CALICO_IP_PREFIX}" | xargs "${here}/evict_queue.py"
+get_node_pods_with_ip_prefix "${NODE}" "${EVICT_PODS_WITH_IP_PREFIX}" | xargs "${here}/evict_queue.py"

--- a/migration/calico-to-cilium/rollback.md
+++ b/migration/calico-to-cilium/rollback.md
@@ -1,0 +1,50 @@
+# I want Calico back
+
+1. Switch the networking plugin back to Calico
+
+    ```bash
+    yq -i '.kube_network_plugin = "calico"' "${CK8S_CONFIG_PATH}/${TARGET_CLUSTER}-config/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml"
+    ../../bin/ck8s-kubespray apply ${TARGET_CLUSTER} --tags download,network
+    ```
+
+1. Restore the Calico CNI config in favor of Cilium
+
+    ```bash
+    cilium-cli uninstall
+    ../../bin/ck8s-kubespray run-playbook ${TARGET_CLUSTER} ../../playbooks/rollback_cilium.yml -b
+    ```
+
+1. Migrate nodes one by one back to Calico
+
+- Get the list of worker nodes and migrate them one by one, passing the node name as argument to the `./20-migrate-node.sh` script:
+
+    ```bash
+    kubectl get nodes --no-headers -o custom-columns=":metadata.name" |
+      grep -v 'control-plane' |
+      xargs -rt -I{} --interactive ./20-migrate-node.sh {} --rollback
+    ```
+
+- Get the list of control plane nodes and migrate them one by one, passing the node name as argument to the `./20-migrate-node.sh` script:
+
+    ```bash
+    kubectl get nodes --no-headers -o custom-columns=":metadata.name" |
+      grep 'control-plane' |
+      xargs -rt -I{} --interactive ./20-migrate-node.sh {} --rollback
+    ```
+
+    >[!NOTE]
+    > Notice the `--rollback` argument to the `20-migrate-node.sh` script
+
+1. (Optional) Nuclear option: evict all pods
+
+- If feeling adventurous, you can skip the step before this and just evict all pods in the system with Cilium IPs:
+
+  ```bash
+  CILIUM_PREFIX="10.235"
+  kubectl get pods --all-namespaces -o json |
+      jq -r --arg ip_test "^${CILIUM_PREFIX}" '
+        .items[] |
+        select(.status.phase == "Running" or .status.pahse == "Pending") |
+        select(.status.podIP | test($ip_test)) |
+        "\(.metadata.namespace)/\(.metadata.name)"' | xargs ./evict_queue.py
+  ```

--- a/playbooks/rollback_cilium.yml
+++ b/playbooks/rollback_cilium.yml
@@ -1,0 +1,7 @@
+- hosts: all
+  tasks:
+    - name: Give priority to the calico CNI config instead of cilium
+      shell: |
+        test -f /etc/cni/net.d/05-cilium.conflist && mv /etc/cni/net.d/05-cilium.conflist /etc/cni/net.d/05-cilium.conflist.calico_bak || true
+        test -f /etc/cni/net.d/10-calico.conflist.cilium_bak && mv /etc/cni/net.d/10-calico.conflist.cilium_bak /etc/cni/net.d/10-calico.conflist || true
+      register: command_output


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

Implements and adds a rollback guide for the Calico to Cilium migration, in case something goes wrong and we want a quick way to change back to the old CNI.

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - bin: changes to management binaries
    - config: changes to configuration
    - deploy: changes to deployments
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [ ] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
