### PR TITLE
replaced deprecated etcd_kubeadm_enabled: true

### DIFF
--- a/config/default/group_vars/k8s_cluster/ck8s-k8s-cluster-default.yaml
+++ b/config/default/group_vars/k8s_cluster/ck8s-k8s-cluster-default.yaml
@@ -1,1 +1,1 @@
-etcd_kubeadm_enabled: true
+etcd_deployment_type: kubeadm

--- a/config/gcp/group_vars/k8s_cluster/ck8s-k8s-cluster-gcp.yaml
+++ b/config/gcp/group_vars/k8s_cluster/ck8s-k8s-cluster-gcp.yaml
@@ -1,2 +1,2 @@
-etcd_kubeadm_enabled: true
+etcd_deployment_type: kubeadm
 persistent_volumes_enabled: true

--- a/config/vsphere/group_vars/k8s_cluster/ck8s-k8s-cluster-vsphere.yaml
+++ b/config/vsphere/group_vars/k8s_cluster/ck8s-k8s-cluster-vsphere.yaml
@@ -1,4 +1,4 @@
-etcd_kubeadm_enabled: true
+etcd_deployment_type: kubeadm
 
 cloud_provider: "external"
 external_cloud_provider: "vsphere"

--- a/docs/migrate-from-cluster.md
+++ b/docs/migrate-from-cluster.md
@@ -130,7 +130,7 @@ This has only been tested on CityCloud and might not look the same for other clo
     Add the following to the `k8s-cluster` group
 
     ```yaml
-    etcd_kubeadm_enabled: true
+    etcd_deployment_type: kubeadm
     kube_cert_dir: "/etc/kubernetes/pki"
     kube_service_addresses: "10.96.0.0/12"
     kube_pods_subnet: "192.168.0.0/16"


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [x] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

`etcd_kubeadm_enabled: true` has been deprecated for a while and finally got removed in v2.28.0. But we still had the old deprecated one as default, which means if you didn't select a particular cloud that had the updated version `etcd_deployment_type: kubeadm` (e.g. openstack, upcloud), you would still get the now removed `etcd_kubeadm_enabled` and thus run into an error when trying to upgrade to v2.28.0.

In this PR I have just changed the `ck8s-k8s-cluster-default.yaml` to use the new non-deprecated version.

I have also created a follow up issue to create a migration script for v2.28.0 that just checks if this old snippet exists and then change it to new non-deprecated version automatically. Can be found here: https://github.com/elastisys/compliantkubernetes-kubespray/issues/470

<!-- Add description of the change -->
...

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - bin: changes to management binaries
    - config: changes to configuration
    - deploy: changes to deployments
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [ ] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
