### PR TITLE
Add archive support for Kubespray

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+version.json export-subst
+
+.github/ export-ignore
+release/ export-ignore

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,7 +2,7 @@ blank_issues_enabled: false
 contact_links:
   - name: Create Release
     about: Please create the release issue in the internal Issue Tracker repository. - Only accessible by maintainers.
-    url: https://github.com/elastisys/ck8s-issue-tracker/issues/new?template=release-kubespray.md
+    url: https://github.com/elastisys/ck8s-issue-tracker/issues/new?template=release.yml
   - name: Create Patch
     about: Please create the patch issue in the internal Issue Tracker repository. - Only accessible by maintainers.
-    url: https://github.com/elastisys/ck8s-issue-tracker/issues/new?template=patch-kubespray.md
+    url: https://github.com/elastisys/ck8s-issue-tracker/issues/new?template=patch.yml

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -15,8 +15,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-        with:
-          submodules: true
 
       - name: Setup Python
         uses: actions/setup-python@v6

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          submodules: true
 
       - name: Setup Python
         uses: actions/setup-python@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           fetch-depth: 0
           ssh-key: ${{ secrets.PRIVATE_SIGNING_AUTH_KEY }}
+          submodules: recursive
 
       - name: Import GPG key
         env:
@@ -51,8 +52,40 @@ jobs:
         id: create_archive
         run: |
           ARCHIVE_NAME="${GITHUB_REPOSITORY##*/}-${{ steps.create_tag.outputs.TAG_NAME }}"
-          git archive --format=zip --output="${ARCHIVE_NAME}.zip" HEAD
-          git archive --format=tar HEAD | gzip --best > "${ARCHIVE_NAME}.tar.gz"
+          TEMP_DIR=$(mktemp -d)
+          # export variables to be able to access them within `git submodule foreach`
+          export ARCHIVE_NAME
+          export TEMP_DIR
+
+          # zip archive
+          # -----------
+          # since zip does not support concatenating multiple zips, we use git archive and pipe it to tar to extract
+          # the main repo and its submodules to a temporary directory, while respecting .gitattributes and keeping
+          # the same folder structure
+          git archive --format=tar HEAD | tar -x -C "${TEMP_DIR}"
+          git submodule foreach --recursive '
+              # `displaypath` is a `submodule foreach` command for the relative path from the CWD to the root directory
+              mkdir -p "${TEMP_DIR}/${displaypath}"
+              git archive --format=tar HEAD | tar -x -C "${TEMP_DIR}/${displaypath}"
+          '
+          pushd "${TEMP_DIR}"
+          # zip main repo and any submodules into one
+          zip -r "${GITHUB_WORKSPACE}/${ARCHIVE_NAME}.zip" .
+          popd
+          rm -rf "${TEMP_DIR}"
+
+          # tar archive
+          # -----------
+          # create tar of the main repo which will not include any submodules
+          git archive --format=tar --output="${GITHUB_WORKSPACE}/${ARCHIVE_NAME}.tar" HEAD
+          git submodule foreach --recursive '
+              # create tar of submodule with prefix of the submodule name to preserve folder structure
+              git archive --format=tar --prefix="${displaypath}/" --output="${displaypath}.tar" HEAD
+              # merge submodule tar with the main repo tar
+              tar --concatenate --file="${GITHUB_WORKSPACE}/${ARCHIVE_NAME}.tar" "${displaypath}.tar"
+              rm "${displaypath}.tar"
+          '
+          gzip --best --verbose "${GITHUB_WORKSPACE}/${ARCHIVE_NAME}.tar"
           gpg --batch --yes --output "${ARCHIVE_NAME}.zip.asc" --armor --detach-sign "${ARCHIVE_NAME}.zip"
           gpg --batch --yes --output "${ARCHIVE_NAME}.tar.gz.asc" --armor --detach-sign "${ARCHIVE_NAME}.tar.gz"
           echo "ARCHIVE_NAME=${ARCHIVE_NAME}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,16 @@ jobs:
           git push --atomic origin "${{ github.ref_name}}" "${TAG_NAME}"
           echo "TAG_NAME=${TAG_NAME}" >> "${GITHUB_OUTPUT}"
 
+      - name: Create Signed Archive
+        id: create_archive
+        run: |
+          ARCHIVE_NAME="${GITHUB_REPOSITORY##*/}-${{ steps.create_tag.outputs.TAG_NAME }}"
+          git archive --format=zip --output="${ARCHIVE_NAME}.zip" HEAD
+          git archive --format=tar HEAD | gzip --best > "${ARCHIVE_NAME}.tar.gz"
+          gpg --batch --yes --output "${ARCHIVE_NAME}.zip.asc" --armor --detach-sign "${ARCHIVE_NAME}.zip"
+          gpg --batch --yes --output "${ARCHIVE_NAME}.tar.gz.asc" --armor --detach-sign "${ARCHIVE_NAME}.tar.gz"
+          echo "ARCHIVE_NAME=${ARCHIVE_NAME}" >> "${GITHUB_OUTPUT}"
+
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
@@ -55,3 +65,7 @@ jobs:
             See [CHANGELOG](https://github.com/elastisys/compliantkubernetes-kubespray/blob/${{ github.ref_name }}/changelog/${{ steps.get_series.outputs.SERIES }}.md) for details.
           files: |
             public.signing.key
+            ${{ steps.create_archive.outputs.ARCHIVE_NAME }}.zip
+            ${{ steps.create_archive.outputs.ARCHIVE_NAME }}.zip.asc
+            ${{ steps.create_archive.outputs.ARCHIVE_NAME }}.tar.gz
+            ${{ steps.create_archive.outputs.ARCHIVE_NAME }}.tar.gz.asc

--- a/bin/common.bash
+++ b/bin/common.bash
@@ -149,7 +149,7 @@ check_tools() {
 
 # Retrieve repo version from git or version file
 get_repo_version() {
-  if [[ $(git rev-parse --is-inside-work-tree 2>/dev/null) == "true" ]]; then
+  if [[ $(git -C "${root_path}" rev-parse --is-inside-work-tree 2>/dev/null) == "true" ]]; then
     git -C "${root_path}" describe --exact-match --tags 2>/dev/null || git -C "${root_path}" rev-parse HEAD
   else
     local release_tag

--- a/bin/common.bash
+++ b/bin/common.bash
@@ -35,6 +35,8 @@ kubespray_path="${root_path}/kubespray"
 config_path="${CK8S_CONFIG_PATH}/${prefix}-config"
 sops_config="${CK8S_CONFIG_PATH}/.sops.yaml"
 
+welkin_version_file="${root_path}/version.json"
+
 # Set the path to search for dynamic inventories
 export TERRAFORM_STATE_ROOT="${config_path}"
 
@@ -145,11 +147,19 @@ check_tools() {
   fi
 }
 
-# Retrieve version from git
+# Retrieve repo version from git or version file
 get_repo_version() {
-  pushd "${root_path}" >/dev/null || exit 1
-  git describe --exact-match --tags 2>/dev/null || git rev-parse HEAD
-  popd >/dev/null || exit 1
+  if [[ $(git rev-parse --is-inside-work-tree 2>/dev/null) == "true" ]]; then
+    git -C "${root_path}" describe --exact-match --tags 2>/dev/null || git -C "${root_path}" rev-parse HEAD
+  else
+    local release_tag
+    release_tag=$(jq -r '.version' "${welkin_version_file}")
+    if [[ -z "${release_tag}" ]]; then
+      jq -r '.commit' "${welkin_version_file}"
+    else
+      echo "${release_tag}"
+    fi
+  fi
 }
 
 validate_sops_config() {

--- a/migration/template/README.md
+++ b/migration/template/README.md
@@ -20,6 +20,8 @@
 
 1. Pull the latest changes, switch to the correct branch and update Kubespray submodule:
 
+    > If you are upgrading from a zip you can skip this step
+
     ```bash
     git pull
     git switch -d ${full_version}

--- a/migration/template/prepare/10-init.sh
+++ b/migration/template/prepare/10-init.sh
@@ -11,11 +11,11 @@ if [[ "${CK8S_CLUSTER}" =~ ^(sc|both)$ ]]; then
   cp "${ROOT}/config/common/group_vars/all/ck8s-image-tags.yaml" "${CK8S_CONFIG_PATH}/sc-config/group_vars/all/"
   cp "${ROOT}/config/common/group_vars/all/ck8s-kubeadm-patches.yaml" "${CK8S_CONFIG_PATH}/sc-config/group_vars/all/"
   cp "${ROOT}/config/ck8s-kube-proxy-image" "${CK8S_CONFIG_PATH}/sc-config/"
-  yq_add sc all/ck8s-kubespray-general .ck8sKubesprayVersion "\"$(git_version)\""
+  yq_add sc all/ck8s-kubespray-general .ck8sKubesprayVersion "\"$(get_repo_version)\""
 fi
 if [[ "${CK8S_CLUSTER}" =~ ^(wc|both)$ ]]; then
   cp "${ROOT}/config/common/group_vars/all/ck8s-image-tags.yaml" "${CK8S_CONFIG_PATH}/wc-config/group_vars/all/"
   cp "${ROOT}/config/common/group_vars/all/ck8s-kubeadm-patches.yaml" "${CK8S_CONFIG_PATH}/wc-config/group_vars/all/"
   cp "${ROOT}/config/ck8s-kube-proxy-image" "${CK8S_CONFIG_PATH}/wc-config/"
-  yq_add wc all/ck8s-kubespray-general .ck8sKubesprayVersion "\"$(git_version)\""
+  yq_add wc all/ck8s-kubespray-general .ck8sKubesprayVersion "\"$(get_repo_version)\""
 fi

--- a/migration/v2.31/prepare/10-init.sh
+++ b/migration/v2.31/prepare/10-init.sh
@@ -11,11 +11,11 @@ if [[ "${CK8S_CLUSTER}" =~ ^(sc|both)$ ]]; then
   cp "${ROOT}/config/common/group_vars/all/ck8s-image-tags.yaml" "${CK8S_CONFIG_PATH}/sc-config/group_vars/all/"
   cp "${ROOT}/config/common/group_vars/all/ck8s-kubeadm-patches.yaml" "${CK8S_CONFIG_PATH}/sc-config/group_vars/all/"
   cp "${ROOT}/config/ck8s-kube-proxy-image" "${CK8S_CONFIG_PATH}/sc-config/"
-  yq_add sc all/ck8s-kubespray-general .ck8sKubesprayVersion "\"$(git_version)\""
+  yq_add sc all/ck8s-kubespray-general .ck8sKubesprayVersion "\"$(get_repo_version)\""
 fi
 if [[ "${CK8S_CLUSTER}" =~ ^(wc|both)$ ]]; then
   cp "${ROOT}/config/common/group_vars/all/ck8s-image-tags.yaml" "${CK8S_CONFIG_PATH}/wc-config/group_vars/all/"
   cp "${ROOT}/config/common/group_vars/all/ck8s-kubeadm-patches.yaml" "${CK8S_CONFIG_PATH}/wc-config/group_vars/all/"
   cp "${ROOT}/config/ck8s-kube-proxy-image" "${CK8S_CONFIG_PATH}/wc-config/"
-  yq_add wc all/ck8s-kubespray-general .ck8sKubesprayVersion "\"$(git_version)\""
+  yq_add wc all/ck8s-kubespray-general .ck8sKubesprayVersion "\"$(get_repo_version)\""
 fi

--- a/release/README.md
+++ b/release/README.md
@@ -72,7 +72,7 @@ Running the script above will:
 Generate a CycloneDX SBOM for the staged release:
 
 ```sh
-./sbom/generate.sh X.Y.Z
+./sbom/generate.sh X.Y.Z --require-evaluation
 ```
 
 Running the script above will:

--- a/scripts/migration/lib.sh
+++ b/scripts/migration/lib.sh
@@ -59,7 +59,7 @@ log_fatal() {
 # --- repo version
 
 get_repo_version() {
-  if [[ $(git rev-parse --is-inside-work-tree 2>/dev/null) == "true" ]]; then
+  if [[ $(git -C "${ROOT}" rev-parse --is-inside-work-tree 2>/dev/null) == "true" ]]; then
     git -C "${ROOT}" describe --exact-match --tags 2>/dev/null || git -C "${ROOT}" rev-parse HEAD
   else
     local release_tag

--- a/scripts/migration/lib.sh
+++ b/scripts/migration/lib.sh
@@ -23,6 +23,8 @@ WC_CONFIG_FILES=(
   "wc-config/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml"
 )
 
+WELKIN_VERSION_FILE="${ROOT}/version.json"
+
 # --- logging functions ---
 
 log_info_no_newline() {
@@ -54,10 +56,20 @@ log_fatal() {
   exit 1
 }
 
-# --- git version
+# --- repo version
 
-git_version() {
-  git -C "${ROOT}" describe --exact-match --tags 2>/dev/null || git -C "${ROOT}" rev-parse HEAD
+get_repo_version() {
+  if [[ $(git rev-parse --is-inside-work-tree 2>/dev/null) == "true" ]]; then
+    git -C "${ROOT}" describe --exact-match --tags 2>/dev/null || git -C "${ROOT}" rev-parse HEAD
+  else
+    local release_tag
+    release_tag=$(jq -r '.version' "${WELKIN_VERSION_FILE}")
+    if [[ -z "${release_tag}" ]]; then
+      jq -r '.commit' "${WELKIN_VERSION_FILE}"
+    else
+      echo "${release_tag}"
+    fi
+  fi
 }
 
 # --- config functions ---
@@ -202,7 +214,7 @@ check_version() {
   fi
 
   local repo_version
-  repo_version="$(git_version)"
+  repo_version="$(get_repo_version)"
   if [[ "${repo_version%.*}" == "${CK8S_TARGET_VERSION}" ]]; then
     log_info "valid repository version \"${repo_version}\""
   elif [[ "${repo_version}" == "${VERSION["${1}-config"]}" ]]; then

--- a/version.json
+++ b/version.json
@@ -1,0 +1,5 @@
+{
+  "commit": "$Format:%H$",
+  "version": "$Format:%(describe:tags)$",
+  "date": "$Format:%ci$"
+}


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [x] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice

> If the security risk outweigh the security benefit of disclosure as determined by the CSE answer TBA for all points.

#### Description

_Description of the vulnerability..._

#### Severity

_CVSS 4.0 score of the vulnerability as determined on Welkin itself._

#### How to identify the vulnerability

_Steps to identify..._

#### How to mitigate the vulnerability

_Steps to mitigate..._

#### Upstream security notices

_If any._

-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
Adds signed archives support for the Kubespray repo, similar to the other repos, but Kubespray is a bit special since we have the kubespray fork submodule that we want to include.
The workflow was approved [here](https://github.com/elastisys/welkin-qa/pull/159) and also tested through actions [here](https://github.com/elastisys/welkin-qa/pull/163).

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Part of https://github.com/elastisys/ck8s-issue-tracker/issues/952

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - bin: changes to management binaries
    - config: changes to configuration
    - deploy: changes to deployments
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [ ] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin-public-docs) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin-public-docs) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
