### PR TITLE
Updating service-monitor-crds

### DIFF
--- a/playbooks/crds/crd-servicemonitors.yaml
+++ b/playbooks/crds/crd-servicemonitors.yaml
@@ -1,11 +1,11 @@
-# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.85.0/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
+# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.89.0/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
-    operator.prometheus.io/version: 0.85.0
+    controller-gen.kubebuilder.io/version: v0.19.0
+    operator.prometheus.io/version: 0.89.0
   name: servicemonitors.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com
@@ -52,19 +52,19 @@ spec:
             type: object
           spec:
             description: |-
-              Specification of desired Service selection for target discovery by
+              spec defines the specification of desired Service selection for target discovery by
               Prometheus.
             properties:
               attachMetadata:
                 description: |-
-                  `attachMetadata` defines additional metadata which is added to the
+                  attachMetadata defines additional metadata which is added to the
                   discovered targets.
 
                   It requires Prometheus >= v2.37.0.
                 properties:
                   node:
                     description: |-
-                      When set to true, Prometheus attaches node metadata to the discovered
+                      node when set to true, Prometheus attaches node metadata to the discovered
                       targets.
 
                       The Prometheus service account must have the `list` and `watch`
@@ -73,7 +73,7 @@ spec:
                 type: object
               bodySizeLimit:
                 description: |-
-                  When defined, bodySizeLimit specifies a job level limit on the size
+                  bodySizeLimit when defined, bodySizeLimit specifies a job level limit on the size
                   of uncompressed response body that will be accepted by Prometheus.
 
                   It requires Prometheus >= v2.28.0.
@@ -81,12 +81,12 @@ spec:
                 type: string
               convertClassicHistogramsToNHCB:
                 description: |-
-                  Whether to convert all scraped classic histograms into a native histogram with custom buckets.
+                  convertClassicHistogramsToNHCB defines whether to convert all scraped classic histograms into a native histogram with custom buckets.
                   It requires Prometheus >= v3.0.0.
                 type: boolean
               endpoints:
                 description: |-
-                  List of endpoints part of this ServiceMonitor.
+                  endpoints defines the list of endpoints part of this ServiceMonitor.
                   Defines how to scrape metrics from Kubernetes [Endpoints](https://kubernetes.io/docs/concepts/services-networking/service/#endpoints) objects.
                   In most cases, an Endpoints object is backed by a Kubernetes [Service](https://kubernetes.io/docs/concepts/services-networking/service/) object with the same name and labels.
                 items:
@@ -96,14 +96,14 @@ spec:
                   properties:
                     authorization:
                       description: |-
-                        `authorization` configures the Authorization header credentials to use when
-                        scraping the target.
+                        authorization configures the Authorization header credentials used by
+                        the client.
 
-                        Cannot be set at the same time as `basicAuth`, or `oauth2`.
+                        Cannot be set at the same time as `basicAuth`, `bearerTokenSecret` or `oauth2`.
                       properties:
                         credentials:
-                          description: Selects a key of a Secret in the namespace
-                            that contains the credentials for authentication.
+                          description: credentials defines a key of a Secret in the
+                            namespace that contains the credentials for authentication.
                           properties:
                             key:
                               description: The key of the secret to select from.  Must
@@ -128,7 +128,7 @@ spec:
                           x-kubernetes-map-type: atomic
                         type:
                           description: |-
-                            Defines the authentication type. The value is case-insensitive.
+                            type defines the authentication type. The value is case-insensitive.
 
                             "Basic" is not a supported value.
 
@@ -137,14 +137,14 @@ spec:
                       type: object
                     basicAuth:
                       description: |-
-                        `basicAuth` configures the Basic Authentication credentials to use when
-                        scraping the target.
+                        basicAuth defines the Basic Authentication credentials used by the
+                        client.
 
-                        Cannot be set at the same time as `authorization`, or `oauth2`.
+                        Cannot be set at the same time as `authorization`, `bearerTokenSecret` or `oauth2`.
                       properties:
                         password:
                           description: |-
-                            `password` specifies a key of a Secret containing the password for
+                            password defines a key of a Secret containing the password for
                             authentication.
                           properties:
                             key:
@@ -170,7 +170,7 @@ spec:
                           x-kubernetes-map-type: atomic
                         username:
                           description: |-
-                            `username` specifies a key of a Secret containing the username for
+                            username defines a key of a Secret containing the username for
                             authentication.
                           properties:
                             key:
@@ -197,15 +197,18 @@ spec:
                       type: object
                     bearerTokenFile:
                       description: |-
-                        File to read bearer token for scraping the target.
+                        bearerTokenFile defines the file to read bearer token for scraping the target.
 
                         Deprecated: use `authorization` instead.
                       type: string
                     bearerTokenSecret:
                       description: |-
-                        `bearerTokenSecret` specifies a key of a Secret containing the bearer
-                        token for scraping targets. The secret needs to be in the same namespace
-                        as the ServiceMonitor object and readable by the Prometheus Operator.
+                        bearerTokenSecret defines a key of a Secret containing the bearer token
+                        used by the client for authentication. The secret needs to be in the
+                        same namespace as the custom resource and readable by the Prometheus
+                        Operator.
+
+                        Cannot be set at the same time as `authorization`, `basicAuth` or `oauth2`.
 
                         Deprecated: use `authorization` instead.
                       properties:
@@ -231,12 +234,11 @@ spec:
                       type: object
                       x-kubernetes-map-type: atomic
                     enableHttp2:
-                      description: '`enableHttp2` can be used to disable HTTP2 when
-                        scraping the target.'
+                      description: enableHttp2 can be used to disable HTTP2.
                       type: boolean
                     filterRunning:
                       description: |-
-                        When true, the pods which are not running (e.g. either in Failed or
+                        filterRunning when true, the pods which are not running (e.g. either in Failed or
                         Succeeded state) are dropped during the target discovery.
 
                         If unset, the filtering is enabled.
@@ -245,29 +247,29 @@ spec:
                       type: boolean
                     followRedirects:
                       description: |-
-                        `followRedirects` defines whether the scrape requests should follow HTTP
-                        3xx redirects.
+                        followRedirects defines whether the client should follow HTTP 3xx
+                        redirects.
                       type: boolean
                     honorLabels:
                       description: |-
-                        When true, `honorLabels` preserves the metric's labels when they collide
+                        honorLabels defines when true the metric's labels when they collide
                         with the target's labels.
                       type: boolean
                     honorTimestamps:
                       description: |-
-                        `honorTimestamps` controls whether Prometheus preserves the timestamps
+                        honorTimestamps defines whether Prometheus preserves the timestamps
                         when exposed by the target.
                       type: boolean
                     interval:
                       description: |-
-                        Interval at which Prometheus scrapes the metrics from the target.
+                        interval at which Prometheus scrapes the metrics from the target.
 
                         If empty, Prometheus uses the global scrape interval.
                       pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                       type: string
                     metricRelabelings:
                       description: |-
-                        `metricRelabelings` configures the relabeling rules to apply to the
+                        metricRelabelings defines the relabeling rules to apply to the
                         samples before ingestion.
                       items:
                         description: |-
@@ -279,7 +281,7 @@ spec:
                           action:
                             default: replace
                             description: |-
-                              Action to perform based on the regex matching.
+                              action to perform based on the regex matching.
 
                               `Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.
                               `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
@@ -311,41 +313,41 @@ spec:
                             type: string
                           modulus:
                             description: |-
-                              Modulus to take of the hash of the source label values.
+                              modulus to take of the hash of the source label values.
 
                               Only applicable when the action is `HashMod`.
                             format: int64
                             type: integer
                           regex:
-                            description: Regular expression against which the extracted
-                              value is matched.
+                            description: regex defines the regular expression against
+                              which the extracted value is matched.
                             type: string
                           replacement:
                             description: |-
-                              Replacement value against which a Replace action is performed if the
+                              replacement value against which a Replace action is performed if the
                               regular expression matches.
 
                               Regex capture groups are available.
                             type: string
                           separator:
-                            description: Separator is the string between concatenated
+                            description: separator defines the string between concatenated
                               SourceLabels.
                             type: string
                           sourceLabels:
                             description: |-
-                              The source labels select values from existing labels. Their content is
+                              sourceLabels defines the source labels select values from existing labels. Their content is
                               concatenated using the configured Separator and matched against the
                               configured regular expression.
                             items:
                               description: |-
-                                LabelName is a valid Prometheus label name which may only contain ASCII
-                                letters, numbers, as well as underscores.
-                              pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                                LabelName is a valid Prometheus label name.
+                                For Prometheus 3.x, a label name is valid if it contains UTF-8 characters.
+                                For Prometheus 2.x, a label name is only valid if it contains ASCII characters, letters, numbers, as well as underscores.
                               type: string
                             type: array
                           targetLabel:
                             description: |-
-                              Label to which the resulting string is written in a replacement.
+                              targetLabel defines the label to which the resulting string is written in a replacement.
 
                               It is mandatory for `Replace`, `HashMod`, `Lowercase`, `Uppercase`,
                               `KeepEqual` and `DropEqual` actions.
@@ -356,7 +358,7 @@ spec:
                       type: array
                     noProxy:
                       description: |-
-                        `noProxy` is a comma-separated string that can contain IPs, CIDR notation, domain names
+                        noProxy defines a comma-separated string that can contain IPs, CIDR notation, domain names
                         that should be excluded from proxying. IP and domain names can
                         contain port numbers.
 
@@ -364,20 +366,20 @@ spec:
                       type: string
                     oauth2:
                       description: |-
-                        `oauth2` configures the OAuth2 settings to use when scraping the target.
+                        oauth2 defines the OAuth2 settings used by the client.
 
                         It requires Prometheus >= 2.27.0.
 
-                        Cannot be set at the same time as `authorization`, or `basicAuth`.
+                        Cannot be set at the same time as `authorization`, `basicAuth` or `bearerTokenSecret`.
                       properties:
                         clientId:
                           description: |-
-                            `clientId` specifies a key of a Secret or ConfigMap containing the
+                            clientId defines a key of a Secret or ConfigMap containing the
                             OAuth2 client's ID.
                           properties:
                             configMap:
-                              description: ConfigMap containing data to use for the
-                                targets.
+                              description: configMap defines the ConfigMap containing
+                                data to use for the targets.
                               properties:
                                 key:
                                   description: The key to select.
@@ -400,7 +402,8 @@ spec:
                               type: object
                               x-kubernetes-map-type: atomic
                             secret:
-                              description: Secret containing data to use for the targets.
+                              description: secret defines the Secret containing data
+                                to use for the targets.
                               properties:
                                 key:
                                   description: The key of the secret to select from.  Must
@@ -426,7 +429,7 @@ spec:
                           type: object
                         clientSecret:
                           description: |-
-                            `clientSecret` specifies a key of a Secret containing the OAuth2
+                            clientSecret defines a key of a Secret containing the OAuth2
                             client's secret.
                           properties:
                             key:
@@ -454,12 +457,12 @@ spec:
                           additionalProperties:
                             type: string
                           description: |-
-                            `endpointParams` configures the HTTP parameters to append to the token
+                            endpointParams configures the HTTP parameters to append to the token
                             URL.
                           type: object
                         noProxy:
                           description: |-
-                            `noProxy` is a comma-separated string that can contain IPs, CIDR notation, domain names
+                            noProxy defines a comma-separated string that can contain IPs, CIDR notation, domain names
                             that should be excluded from proxying. IP and domain names can
                             contain port numbers.
 
@@ -493,7 +496,7 @@ spec:
                               x-kubernetes-map-type: atomic
                             type: array
                           description: |-
-                            ProxyConnectHeader optionally specifies headers to send to
+                            proxyConnectHeader optionally specifies headers to send to
                             proxies during CONNECT requests.
 
                             It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
@@ -501,33 +504,32 @@ spec:
                           x-kubernetes-map-type: atomic
                         proxyFromEnvironment:
                           description: |-
-                            Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
+                            proxyFromEnvironment defines whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
                             It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                           type: boolean
                         proxyUrl:
-                          description: '`proxyURL` defines the HTTP proxy server to
-                            use.'
+                          description: proxyUrl defines the HTTP proxy server to use.
                           pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
-                          description: '`scopes` defines the OAuth2 scopes used for
-                            the token request.'
+                          description: scopes defines the OAuth2 scopes used for the
+                            token request.
                           items:
                             type: string
                           type: array
                         tlsConfig:
                           description: |-
-                            TLS configuration to use when connecting to the OAuth2 server.
+                            tlsConfig defines the TLS configuration to use when connecting to the OAuth2 server.
                             It requires Prometheus >= v2.43.0.
                           properties:
                             ca:
-                              description: Certificate authority used when verifying
-                                server certificates.
+                              description: ca defines the Certificate authority used
+                                when verifying server certificates.
                               properties:
                                 configMap:
-                                  description: ConfigMap containing data to use for
-                                    the targets.
+                                  description: configMap defines the ConfigMap containing
+                                    data to use for the targets.
                                   properties:
                                     key:
                                       description: The key to select.
@@ -550,8 +552,8 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 secret:
-                                  description: Secret containing data to use for the
-                                    targets.
+                                  description: secret defines the Secret containing
+                                    data to use for the targets.
                                   properties:
                                     key:
                                       description: The key of the secret to select
@@ -576,12 +578,12 @@ spec:
                                   x-kubernetes-map-type: atomic
                               type: object
                             cert:
-                              description: Client certificate to present when doing
-                                client-authentication.
+                              description: cert defines the Client certificate to
+                                present when doing client-authentication.
                               properties:
                                 configMap:
-                                  description: ConfigMap containing data to use for
-                                    the targets.
+                                  description: configMap defines the ConfigMap containing
+                                    data to use for the targets.
                                   properties:
                                     key:
                                       description: The key to select.
@@ -604,8 +606,8 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 secret:
-                                  description: Secret containing data to use for the
-                                    targets.
+                                  description: secret defines the Secret containing
+                                    data to use for the targets.
                                   properties:
                                     key:
                                       description: The key of the secret to select
@@ -630,11 +632,12 @@ spec:
                                   x-kubernetes-map-type: atomic
                               type: object
                             insecureSkipVerify:
-                              description: Disable target certificate validation.
+                              description: insecureSkipVerify defines how to disable
+                                target certificate validation.
                               type: boolean
                             keySecret:
-                              description: Secret containing the client key file for
-                                the targets.
+                              description: keySecret defines the Secret containing
+                                the client key file for the targets.
                               properties:
                                 key:
                                   description: The key of the secret to select from.  Must
@@ -659,7 +662,7 @@ spec:
                               x-kubernetes-map-type: atomic
                             maxVersion:
                               description: |-
-                                Maximum acceptable TLS version.
+                                maxVersion defines the maximum acceptable TLS version.
 
                                 It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                               enum:
@@ -670,7 +673,7 @@ spec:
                               type: string
                             minVersion:
                               description: |-
-                                Minimum acceptable TLS version.
+                                minVersion defines the minimum acceptable TLS version.
 
                                 It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                               enum:
@@ -680,12 +683,13 @@ spec:
                               - TLS13
                               type: string
                             serverName:
-                              description: Used to verify the hostname for the targets.
+                              description: serverName is used to verify the hostname
+                                for the targets.
                               type: string
                           type: object
                         tokenUrl:
-                          description: '`tokenURL` configures the URL to fetch the
-                            token from.'
+                          description: tokenUrl defines the URL to fetch the token
+                            from.
                           minLength: 1
                           type: string
                       required:
@@ -702,13 +706,13 @@ spec:
                       type: object
                     path:
                       description: |-
-                        HTTP path from which to scrape for metrics.
+                        path defines the HTTP path from which to scrape for metrics.
 
                         If empty, Prometheus uses the default value (e.g. `/metrics`).
                       type: string
                     port:
                       description: |-
-                        Name of the Service port which this endpoint refers to.
+                        port defines the name of the Service port which this endpoint refers to.
 
                         It takes precedence over `targetPort`.
                       type: string
@@ -740,7 +744,7 @@ spec:
                           x-kubernetes-map-type: atomic
                         type: array
                       description: |-
-                        ProxyConnectHeader optionally specifies headers to send to
+                        proxyConnectHeader optionally specifies headers to send to
                         proxies during CONNECT requests.
 
                         It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
@@ -748,17 +752,17 @@ spec:
                       x-kubernetes-map-type: atomic
                     proxyFromEnvironment:
                       description: |-
-                        Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
+                        proxyFromEnvironment defines whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
 
                         It requires Prometheus >= v2.43.0, Alertmanager >= v0.25.0 or Thanos >= v0.32.0.
                       type: boolean
                     proxyUrl:
-                      description: '`proxyURL` defines the HTTP proxy server to use.'
+                      description: proxyUrl defines the HTTP proxy server to use.
                       pattern: ^(http|https|socks5)://.+$
                       type: string
                     relabelings:
                       description: |-
-                        `relabelings` configures the relabeling rules to apply the target's
+                        relabelings defines the relabeling rules to apply the target's
                         metadata labels.
 
                         The Operator automatically adds relabelings for a few standard Kubernetes fields.
@@ -776,7 +780,7 @@ spec:
                           action:
                             default: replace
                             description: |-
-                              Action to perform based on the regex matching.
+                              action to perform based on the regex matching.
 
                               `Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.
                               `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
@@ -808,41 +812,41 @@ spec:
                             type: string
                           modulus:
                             description: |-
-                              Modulus to take of the hash of the source label values.
+                              modulus to take of the hash of the source label values.
 
                               Only applicable when the action is `HashMod`.
                             format: int64
                             type: integer
                           regex:
-                            description: Regular expression against which the extracted
-                              value is matched.
+                            description: regex defines the regular expression against
+                              which the extracted value is matched.
                             type: string
                           replacement:
                             description: |-
-                              Replacement value against which a Replace action is performed if the
+                              replacement value against which a Replace action is performed if the
                               regular expression matches.
 
                               Regex capture groups are available.
                             type: string
                           separator:
-                            description: Separator is the string between concatenated
+                            description: separator defines the string between concatenated
                               SourceLabels.
                             type: string
                           sourceLabels:
                             description: |-
-                              The source labels select values from existing labels. Their content is
+                              sourceLabels defines the source labels select values from existing labels. Their content is
                               concatenated using the configured Separator and matched against the
                               configured regular expression.
                             items:
                               description: |-
-                                LabelName is a valid Prometheus label name which may only contain ASCII
-                                letters, numbers, as well as underscores.
-                              pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                                LabelName is a valid Prometheus label name.
+                                For Prometheus 3.x, a label name is valid if it contains UTF-8 characters.
+                                For Prometheus 2.x, a label name is only valid if it contains ASCII characters, letters, numbers, as well as underscores.
                               type: string
                             type: array
                           targetLabel:
                             description: |-
-                              Label to which the resulting string is written in a replacement.
+                              targetLabel defines the label to which the resulting string is written in a replacement.
 
                               It is mandatory for `Replace`, `HashMod`, `Lowercase`, `Uppercase`,
                               `KeepEqual` and `DropEqual` actions.
@@ -852,20 +856,17 @@ spec:
                         type: object
                       type: array
                     scheme:
-                      description: |-
-                        HTTP scheme to use for scraping.
-
-                        `http` and `https` are the expected values unless you rewrite the
-                        `__scheme__` label via relabeling.
-
-                        If empty, Prometheus uses the default value `http`.
+                      description: scheme defines the HTTP scheme to use when scraping
+                        the metrics.
                       enum:
                       - http
                       - https
+                      - HTTP
+                      - HTTPS
                       type: string
                     scrapeTimeout:
                       description: |-
-                        Timeout after which Prometheus considers the scrape to be failed.
+                        scrapeTimeout defines the timeout after which Prometheus considers the scrape to be failed.
 
                         If empty, Prometheus uses the global scrape timeout unless it is less
                         than the target's scrape interval value in which the latter is used.
@@ -877,19 +878,20 @@ spec:
                       - type: integer
                       - type: string
                       description: |-
-                        Name or number of the target port of the `Pod` object behind the
+                        targetPort defines the name or number of the target port of the `Pod` object behind the
                         Service. The port must be specified with the container's port property.
                       x-kubernetes-int-or-string: true
                     tlsConfig:
-                      description: TLS configuration to use when scraping the target.
+                      description: tlsConfig defines TLS configuration used by the
+                        client.
                       properties:
                         ca:
-                          description: Certificate authority used when verifying server
-                            certificates.
+                          description: ca defines the Certificate authority used when
+                            verifying server certificates.
                           properties:
                             configMap:
-                              description: ConfigMap containing data to use for the
-                                targets.
+                              description: configMap defines the ConfigMap containing
+                                data to use for the targets.
                               properties:
                                 key:
                                   description: The key to select.
@@ -912,7 +914,8 @@ spec:
                               type: object
                               x-kubernetes-map-type: atomic
                             secret:
-                              description: Secret containing data to use for the targets.
+                              description: secret defines the Secret containing data
+                                to use for the targets.
                               properties:
                                 key:
                                   description: The key of the secret to select from.  Must
@@ -937,15 +940,16 @@ spec:
                               x-kubernetes-map-type: atomic
                           type: object
                         caFile:
-                          description: Path to the CA cert in the Prometheus container
-                            to use for the targets.
+                          description: caFile defines the path to the CA cert in the
+                            Prometheus container to use for the targets.
                           type: string
                         cert:
-                          description: Client certificate to present when doing client-authentication.
+                          description: cert defines the Client certificate to present
+                            when doing client-authentication.
                           properties:
                             configMap:
-                              description: ConfigMap containing data to use for the
-                                targets.
+                              description: configMap defines the ConfigMap containing
+                                data to use for the targets.
                               properties:
                                 key:
                                   description: The key to select.
@@ -968,7 +972,8 @@ spec:
                               type: object
                               x-kubernetes-map-type: atomic
                             secret:
-                              description: Secret containing data to use for the targets.
+                              description: secret defines the Secret containing data
+                                to use for the targets.
                               properties:
                                 key:
                                   description: The key of the secret to select from.  Must
@@ -993,19 +998,20 @@ spec:
                               x-kubernetes-map-type: atomic
                           type: object
                         certFile:
-                          description: Path to the client cert file in the Prometheus
-                            container for the targets.
+                          description: certFile defines the path to the client cert
+                            file in the Prometheus container for the targets.
                           type: string
                         insecureSkipVerify:
-                          description: Disable target certificate validation.
+                          description: insecureSkipVerify defines how to disable target
+                            certificate validation.
                           type: boolean
                         keyFile:
-                          description: Path to the client key file in the Prometheus
-                            container for the targets.
+                          description: keyFile defines the path to the client key
+                            file in the Prometheus container for the targets.
                           type: string
                         keySecret:
-                          description: Secret containing the client key file for the
-                            targets.
+                          description: keySecret defines the Secret containing the
+                            client key file for the targets.
                           properties:
                             key:
                               description: The key of the secret to select from.  Must
@@ -1030,7 +1036,7 @@ spec:
                           x-kubernetes-map-type: atomic
                         maxVersion:
                           description: |-
-                            Maximum acceptable TLS version.
+                            maxVersion defines the maximum acceptable TLS version.
 
                             It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
                           enum:
@@ -1041,7 +1047,7 @@ spec:
                           type: string
                         minVersion:
                           description: |-
-                            Minimum acceptable TLS version.
+                            minVersion defines the minimum acceptable TLS version.
 
                             It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
                           enum:
@@ -1051,12 +1057,13 @@ spec:
                           - TLS13
                           type: string
                         serverName:
-                          description: Used to verify the hostname for the targets.
+                          description: serverName is used to verify the hostname for
+                            the targets.
                           type: string
                       type: object
                     trackTimestampsStaleness:
                       description: |-
-                        `trackTimestampsStaleness` defines whether Prometheus tracks staleness of
+                        trackTimestampsStaleness defines whether Prometheus tracks staleness of
                         the metrics that have an explicit timestamp present in scraped data.
                         Has no effect if `honorTimestamps` is false.
 
@@ -1066,7 +1073,7 @@ spec:
                 type: array
               fallbackScrapeProtocol:
                 description: |-
-                  The protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.
+                  fallbackScrapeProtocol defines the protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.
 
                   It requires Prometheus >= v3.0.0.
                 enum:
@@ -1078,7 +1085,7 @@ spec:
                 type: string
               jobLabel:
                 description: |-
-                  `jobLabel` selects the label from the associated Kubernetes `Service`
+                  jobLabel selects the label from the associated Kubernetes `Service`
                   object which will be used as the `job` label for all metrics.
 
                   For example if `jobLabel` is set to `foo` and the Kubernetes `Service`
@@ -1091,7 +1098,7 @@ spec:
                 type: string
               keepDroppedTargets:
                 description: |-
-                  Per-scrape limit on the number of targets dropped by relabeling
+                  keepDroppedTargets defines the per-scrape limit on the number of targets dropped by relabeling
                   that will be kept in memory. 0 means no limit.
 
                   It requires Prometheus >= v2.47.0.
@@ -1099,44 +1106,45 @@ spec:
                 type: integer
               labelLimit:
                 description: |-
-                  Per-scrape limit on number of labels that will be accepted for a sample.
+                  labelLimit defines the per-scrape limit on number of labels that will be accepted for a sample.
 
                   It requires Prometheus >= v2.27.0.
                 format: int64
                 type: integer
               labelNameLengthLimit:
                 description: |-
-                  Per-scrape limit on length of labels name that will be accepted for a sample.
+                  labelNameLengthLimit defines the per-scrape limit on length of labels name that will be accepted for a sample.
 
                   It requires Prometheus >= v2.27.0.
                 format: int64
                 type: integer
               labelValueLengthLimit:
                 description: |-
-                  Per-scrape limit on length of labels value that will be accepted for a sample.
+                  labelValueLengthLimit defines the per-scrape limit on length of labels value that will be accepted for a sample.
 
                   It requires Prometheus >= v2.27.0.
                 format: int64
                 type: integer
               namespaceSelector:
                 description: |-
-                  `namespaceSelector` defines in which namespace(s) Prometheus should discover the services.
+                  namespaceSelector defines in which namespace(s) Prometheus should discover the services.
                   By default, the services are discovered in the same namespace as the `ServiceMonitor` object but it is possible to select pods across different/all namespaces.
                 properties:
                   any:
                     description: |-
-                      Boolean describing whether all namespaces are selected in contrast to a
+                      any defines the boolean describing whether all namespaces are selected in contrast to a
                       list restricting them.
                     type: boolean
                   matchNames:
-                    description: List of namespace names to select from.
+                    description: matchNames defines the list of namespace names to
+                      select from.
                     items:
                       type: string
                     type: array
                 type: object
               nativeHistogramBucketLimit:
                 description: |-
-                  If there are more than this many buckets in a native histogram,
+                  nativeHistogramBucketLimit defines ff there are more than this many buckets in a native histogram,
                   buckets will be merged to stay within the limit.
                   It requires Prometheus >= v2.45.0.
                 format: int64
@@ -1146,38 +1154,43 @@ spec:
                 - type: integer
                 - type: string
                 description: |-
-                  If the growth factor of one bucket to the next is smaller than this,
+                  nativeHistogramMinBucketFactor defines if the growth factor of one bucket to the next is smaller than this,
                   buckets will be merged to increase the factor sufficiently.
                   It requires Prometheus >= v2.50.0.
                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                 x-kubernetes-int-or-string: true
               podTargetLabels:
                 description: |-
-                  `podTargetLabels` defines the labels which are transferred from the
+                  podTargetLabels defines the labels which are transferred from the
                   associated Kubernetes `Pod` object onto the ingested metrics.
                 items:
                   type: string
                 type: array
               sampleLimit:
                 description: |-
-                  `sampleLimit` defines a per-scrape limit on the number of scraped samples
+                  sampleLimit defines a per-scrape limit on the number of scraped samples
                   that will be accepted.
                 format: int64
                 type: integer
               scrapeClass:
-                description: The scrape class to apply.
+                description: scrapeClass defines the scrape class to apply.
                 minLength: 1
                 type: string
               scrapeClassicHistograms:
                 description: |-
-                  Whether to scrape a classic histogram that is also exposed as a native histogram.
+                  scrapeClassicHistograms defines whether to scrape a classic histogram that is also exposed as a native histogram.
                   It requires Prometheus >= v2.45.0.
 
                   Notice: `scrapeClassicHistograms` corresponds to the `always_scrape_classic_histograms` field in the Prometheus configuration.
                 type: boolean
+              scrapeNativeHistograms:
+                description: |-
+                  scrapeNativeHistograms defines whether to enable scraping of native histograms.
+                  It requires Prometheus >= v3.8.0.
+                type: boolean
               scrapeProtocols:
                 description: |-
-                  `scrapeProtocols` defines the protocols to negotiate during a scrape. It tells clients the
+                  scrapeProtocols defines the protocols to negotiate during a scrape. It tells clients the
                   protocols supported by Prometheus in order of preference (from most to least preferred).
 
                   If unset, Prometheus uses its default value.
@@ -1202,8 +1215,8 @@ spec:
                 type: array
                 x-kubernetes-list-type: set
               selector:
-                description: Label selector to select the Kubernetes `Endpoints` objects
-                  to scrape metrics from.
+                description: selector defines the label selector to select the Kubernetes
+                  `Endpoints` objects to scrape metrics from.
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -1250,7 +1263,7 @@ spec:
                 x-kubernetes-map-type: atomic
               selectorMechanism:
                 description: |-
-                  Mechanism used to select the endpoints to scrape.
+                  selectorMechanism defines the mechanism used to select the endpoints to scrape.
                   By default, the selection process relies on relabel configurations to filter the discovered targets.
                   Alternatively, you can opt in for role selectors, which may offer better efficiency in large clusters.
                   Which strategy is best for your use case needs to be carefully evaluated.
@@ -1260,16 +1273,27 @@ spec:
                 - RelabelConfig
                 - RoleSelector
                 type: string
+              serviceDiscoveryRole:
+                description: |-
+                  serviceDiscoveryRole defines the service discovery role used to discover targets.
+
+                  If set, the value should be either "Endpoints" or "EndpointSlice".
+                  Otherwise it defaults to the value defined in the
+                  Prometheus/PrometheusAgent resource.
+                enum:
+                - Endpoints
+                - EndpointSlice
+                type: string
               targetLabels:
                 description: |-
-                  `targetLabels` defines the labels which are transferred from the
+                  targetLabels defines the labels which are transferred from the
                   associated Kubernetes `Service` object onto the ingested metrics.
                 items:
                   type: string
                 type: array
               targetLimit:
                 description: |-
-                  `targetLimit` defines a limit on the number of scraped targets that will
+                  targetLimit defines a limit on the number of scraped targets that will
                   be accepted.
                 format: int64
                 type: integer
@@ -1279,7 +1303,7 @@ spec:
             type: object
           status:
             description: |-
-              This Status subresource is under active development and is updated only when the
+              status defines the status subresource. It is under active development and is updated only when the
               "StatusForConfigurationResources" feature gate is enabled.
 
               Most recent observed status of the ServiceMonitor. Read-only.
@@ -1287,47 +1311,48 @@ spec:
               https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
             properties:
               bindings:
-                description: The list of workload resources (Prometheus or PrometheusAgent)
-                  which select the configuration resource.
+                description: bindings defines the list of workload resources (Prometheus,
+                  PrometheusAgent, ThanosRuler or Alertmanager) which select the configuration
+                  resource.
                 items:
                   description: WorkloadBinding is a link between a configuration resource
                     and a workload resource.
                   properties:
                     conditions:
-                      description: The current state of the configuration resource
-                        when bound to the referenced Prometheus object.
+                      description: conditions defines the current state of the configuration
+                        resource when bound to the referenced Workload object.
                       items:
                         description: ConfigResourceCondition describes the status
                           of configuration resources linked to Prometheus, PrometheusAgent,
-                          Alertmanager, or ThanosRuler.
+                          Alertmanager or ThanosRuler.
                         properties:
                           lastTransitionTime:
-                            description: LastTransitionTime is the time of the last
-                              update to the current status property.
+                            description: lastTransitionTime defines the time of the
+                              last update to the current status property.
                             format: date-time
                             type: string
                           message:
-                            description: Human-readable message indicating details
-                              for the condition's last transition.
+                            description: message defines the human-readable message
+                              indicating details for the condition's last transition.
                             type: string
                           observedGeneration:
                             description: |-
-                              ObservedGeneration represents the .metadata.generation that the
+                              observedGeneration defines the .metadata.generation that the
                               condition was set based upon. For instance, if `.metadata.generation` is
                               currently 12, but the `.status.conditions[].observedGeneration` is 9, the
                               condition is out of date with respect to the current state of the object.
                             format: int64
                             type: integer
                           reason:
-                            description: Reason for the condition's last transition.
+                            description: reason for the condition's last transition.
                             type: string
                           status:
-                            description: Status of the condition.
+                            description: status of the condition.
                             minLength: 1
                             type: string
                           type:
                             description: |-
-                              Type of the condition being reported.
+                              type of the condition being reported.
                               Currently, only "Accepted" is supported.
                             enum:
                             - Accepted
@@ -1343,24 +1368,27 @@ spec:
                       - type
                       x-kubernetes-list-type: map
                     group:
-                      description: The group of the referenced resource.
+                      description: group defines the group of the referenced resource.
                       enum:
                       - monitoring.coreos.com
                       type: string
                     name:
-                      description: The name of the referenced object.
+                      description: name defines the name of the referenced object.
                       minLength: 1
                       type: string
                     namespace:
-                      description: The namespace of the referenced object.
+                      description: namespace defines the namespace of the referenced
+                        object.
                       minLength: 1
                       type: string
                     resource:
-                      description: The type of resource being referenced (e.g. Prometheus
-                        or PrometheusAgent).
+                      description: resource defines the type of resource being referenced
+                        (e.g. Prometheus, PrometheusAgent, ThanosRuler or Alertmanager).
                       enum:
                       - prometheuses
                       - prometheusagents
+                      - thanosrulers
+                      - alertmanagers
                       type: string
                   required:
                   - group
@@ -1369,6 +1397,12 @@ spec:
                   - resource
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - name
+                - namespace
+                x-kubernetes-list-type: map
             type: object
         required:
         - spec


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [x] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice

> If the security risk outweigh the security benefit of disclosure as determined by the CSE answer TBA for all points.

#### Description

_Description of the vulnerability..._

#### Severity

_CVSS 4.0 score of the vulnerability as determined on Welkin itself._

#### How to identify the vulnerability

_Steps to identify..._

#### How to mitigate the vulnerability

_Steps to mitigate..._

#### Upstream security notices

_If any._

-->

### What does this PR do / why do we need this PR?
Automatic updates done by running `playbooks/crds/sync.sh`. Marked as a
[pre-requisite for the new Kubespray release](https://github.com/elastisys/compliantkubernetes-kubespray/tree/main/release#prerequisites). 


<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Part of https://github.com/elastisys/ck8s-issue-tracker/issues/1026

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - bin: changes to management binaries
    - config: changes to configuration
    - deploy: changes to deployments
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [ ] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin-public-docs) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin-public-docs) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
